### PR TITLE
Fix `$cordovaCompass` actually the factory name is `$cordovaDeviceOrientation`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,15 +95,15 @@ module.controller('MyCtrl', function($scope, $cordovaBarcodeScanner) {
   });
 ```
 
-### `$cordovaCompass`
+### `$cordovaDeviceOrientation`
 
 Monitor device orientation through the digital compass on a device.
 
 ```javascript
-module.controller('PictureCtrl', function($scope, $cordovaCompass) {
+module.controller('PictureCtrl', function($scope, $cordovaDeviceOrientation) {
   $scope.trackHeading = function() {
     // Pass options in [1]
-    $cordovaCompass.watchHeading(options).then(function() {
+    $cordovaDeviceOrientation.watchHeading(options).then(function() {
       // Not currently used
     }, function(err) {
       // An error occured. Show a message to the user


### PR DESCRIPTION
I was not sure which is the correct but found this name issue, the docs states  `$cordovaCompass` but actually it's `$cordovaDeviceOrientation`
https://github.com/driftyco/ng-cordova/blob/master/src/plugins/deviceOrientation.js
