### PR TITLE
Handle Connection.NONE for offline

### DIFF
--- a/src/plugins/network.js
+++ b/src/plugins/network.js
@@ -9,13 +9,13 @@ angular.module('ngCordova.plugins.network', [])
     },
 
     isOnline: function () {
-      var networkSate = navigator.connection.type;
-      return networkSate != Connection.UNKNOWN;
+      var networkState = navigator.connection.type;
+      return networkState !== Connection.UNKNOWN && networkState !== Connection.NONE;
     },
 
     isOffline: function () {
-      var networkSate = navigator.connection.type;
-      return networkSate == Connection.UNKNOWN;
+      var networkState = navigator.connection.type;
+      return networkSate === Connection.UNKNOWN || networkState === Connection.NONE;
     }
   }
 }]);


### PR DESCRIPTION
Fixed Connection.NONE not being handled as an offline state.

Also corrected a typo `s/Sate/State/` and suggested `===` for string comparisons.

In technical terms, Connection.UNKNOWN doesn't mean offline, literally meaning we don't know, but need more thought on how to handle this. Throw an exception?
