### PR TITLE
BarcodeScanner.scan() does not take in options -- comes back undefined.

### DIFF
--- a/src/plugins/barcodeScanner.js
+++ b/src/plugins/barcodeScanner.js
@@ -10,7 +10,7 @@ angular.module('ngCordova.plugins.barcodeScanner', [])
         q.resolve(result);
       }, function (err) {
         q.reject(err);
-      }, options);
+      });
 
       return q.promise;
     },


### PR DESCRIPTION
This just removes `options` from the call to barcodeScanner. The method only needs a `success` and `failure` function.
