### PR TITLE
Set bower.json to point to main dist file for use with wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,11 +7,7 @@
         "Paolo Bernasconi <paolo.enrico.bernasconi@gmail.com>"
     ],
     "description": "AngularJS Cordova wrappers for common Cordova plugins.",
-    "main": [
-        "dist/*",
-        "src/*",
-        "demo/*"
-    ],
+    "main": "./dist/ng-cordova.js",
     "keywords": [
         "cordova",
         "phonegap",


### PR DESCRIPTION
Currently the "main" key in bower.json isn't pointing to just _dist/ng-codova.js_ so this has been updated. If this is not the desired behaviour then perhaps this can be ignored.

When I installed using bower the bower.json file also wasn't present, it appears that it isn't in the current release.
