### PR TITLE
Removing progress computation logic from plugin wrapper

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -151,10 +151,7 @@ angular.module('ngCordova.plugins.file', [])
         var uri = encodeURI(source);
         
         fileTransfer.onprogress = function(progressEvent) {
-          if (progressEvent.lengthComputable) {
-			var perc = Math.floor(progressEvent.loaded / progressEvent.total * 100);
-			q.notify(perc);
-		  }
+            q.notify(progressEvent);
         };
 
         fileTransfer.download(
@@ -177,10 +174,7 @@ angular.module('ngCordova.plugins.file', [])
         var uri = encodeURI(server);
         
         fileTransfer.onprogress = function(progressEvent) {
-          if (progressEvent.lengthComputable) {
-			var perc = Math.floor(progressEvent.loaded / progressEvent.total * 100);
-			q.notify(perc);
-		  }
+            q.notify(progressEvent);
         };
 
         fileTransfer.upload(


### PR DESCRIPTION
I think that wrapper-approach must minimize result transformations between end-users and cordova plugins.
Users can't currently use 'loaded' or 'total' properties of progressEvent because of percentage computation.
I think its better not to transform plugin result, users can check cordova doc for FileTransfert plugin, see progressEvent structure, and decide what to do.
