### PR TITLE
Avoiding file path transformation in ngcordova.

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -44,12 +44,17 @@ angular.module('ngCordova.plugins.file', [])
         );
       },
 
-      checkFile: function (dir, file) {
+      checkFile: function (filePath) {
         var q = $q.defer();
+
+        // Backward compatibility for previous function checkFile(dir, file)
+        if (arguments.length == 2) {
+            filePath = '/' + filePath + '/' + arguments[1];
+        }
 
         getFilesystem().then(
           function (filesystem) {
-            filesystem.root.getFile('/' + dir + '/' + file, {create: false},
+            filesystem.root.getFile(filePath, {create: false},
               // File exists
               function () {
                 q.resolve();
@@ -65,10 +70,15 @@ angular.module('ngCordova.plugins.file', [])
         return q.promise;
       },
 
-      createFile: function (dir, file, replaceBOOL) {
+      createFile: function (filePath, replaceBOOL) {
+        // Backward compatibility for previous function createFile(dir, file, replaceBOOL)
+        if (arguments.length == 3) {
+            filePath = '/' + filePath + '/' + arguments[1];
+        }
+
         getFilesystem().then(
           function (filesystem) {
-            filesystem.root.getFile('/' + dir + '/' + file, {create: true, exclusive: replaceBOOL},
+            filesystem.root.getFile(filePath, {create: true, exclusive: replaceBOOL},
               function (success) {
 
               },
@@ -79,12 +89,17 @@ angular.module('ngCordova.plugins.file', [])
         );
       },
 
-      removeFile: function (dir, file) {
+      removeFile: function (filePath) {
         var q = $q.defer();
+
+        // Backward compatibility for previous function removeFile(dir, file)
+        if (arguments.length == 2) {
+            filePath = '/' + filePath + '/' + arguments[1];
+        }
 
         getFilesystem().then(
           function (filesystem) {
-            filesystem.root.getFile('/' + dir + '/' + file, {create: false}, function (fileEntry) {
+            filesystem.root.getFile(filePath, {create: false}, function (fileEntry) {
               fileEntry.remove(function () {
                 q.resolve();
               });
@@ -95,12 +110,17 @@ angular.module('ngCordova.plugins.file', [])
         return q.promise;
       },
 
-      writeFile: function (dir, file) {
+      writeFile: function (filePath) {
         var q = $q.defer();
+
+        // Backward compatibility for previous function writeFile(dir, file)
+        if (arguments.length == 2) {
+            filePath = '/' + filePath + '/' + arguments[1];
+        }
 
         getFilesystem().then(
           function (filesystem) {
-            filesystem.root.getFile('/' + dir + '/' + file, {create: false},
+            filesystem.root.getFile(filePath, {create: false},
               function (fileEntry) {
                 fileEntry.createWriter(
                   function (fileWriter) {
@@ -117,13 +137,18 @@ angular.module('ngCordova.plugins.file', [])
         return q.promise;
       },
 
-      readFile: function (dir, file) {
+      readFile: function (filePath) {
         var q = $q.defer();
+
+        // Backward compatibility for previous function readFile(dir, file)
+        if (arguments.length == 2) {
+            filePath = '/' + filePath + '/' + arguments[1];
+        }
 
         getFilesystem().then(
           function (filesystem) {
 
-            filesystem.root.getFile('/' + dir + '/' + file, {create: false},
+            filesystem.root.getFile(filePath, {create: false},
               // success
               function (fileEntry) {
                 fileEntry.file(function (file) {


### PR DESCRIPTION
Can be a good workaround for issue #84
As ngCordova is a wrapper for cordova plugin, avoid when possible to add data transformations, so that user can use ngCordova functions with same parameters as cordova plugins.
