### PR TITLE
Correct the watch() $geolocationCordova method to use clearWatch() with watchId (completing the promise definition)

### DIFF
--- a/src/plugins/geolocation.js
+++ b/src/plugins/geolocation.js
@@ -18,7 +18,7 @@ angular.module('ngCordova.plugins.geolocation', [])
     watchPosition: function(options) {
       var q = $q.defer();
 
-      watchId = navigator.geolocation.watchPosition(function(result) {
+      var watchId = navigator.geolocation.watchPosition(function(result) {
         // Do any magic you need
         q.resolve(watchID);
         q.notify(result);


### PR DESCRIPTION
navigator.geolocation.watchPosition() returns a WatchID, witch identifies the "watching process".
Then this ID is  required to stop this process, using the navigator.geolocation.clearWatch(watchID).

Up to now, the factory didn't handle the watchID, and then didn't throw it to the promise.
I just added the watchId local var to handle and thrown by the resolve() promise method.

So you can update the documentation like this : 

```
module.controller('MyCtrl', function($scope, $cordovaGeolocation) {
    $cordovaGeolocation.getCurrentPosition()
    .then(function(position) {
        // Position here: position.coords.latitude, position.coords.longitude
    }, function(err) {
        // error
    });

    $cordovaGeolocation.watchPosition()
    .then(function(watchID) {
        // Handle de watchID required to use clearWatch(watchID)

    }, function(err) {
        // An error occured. Show a message to the user
    }, function(position) {
        // Active updates of the position here
    });
});
```
