### PR TITLE
Passing the watchID throw the resolve method

### DIFF
--- a/src/plugins/deviceMotion.js
+++ b/src/plugins/deviceMotion.js
@@ -18,8 +18,9 @@ angular.module('ngCordova.plugins.deviceMotion', [])
     watchAcceleration: function(options) {
       var q = $q.defer();
 
-      navigator.accelerometer.watchAcceleration(function(result) {
+      var watchID = navigator.accelerometer.watchAcceleration(function(result) {
         // Do any magic you need
+        q.resolve(watchID);
         q.notify(result);
       }, function(err) {
         q.reject(err);


### PR DESCRIPTION
I just added the watchID local variable to handle the return of watchAcceleration().
Then the promise factory resolve the method passing the watchID to the controllers, this one is required to use clearWatch(id).

So you can update the documentation like this :

```
module.controller('DeviceMotionCtrl', function($scope, $cordovaDeviceMotion) {
    $scope.getAcceleration = function () {
        $cordovaDeviceMotion.getCurrentAcceleration().then(function(result) {
            // Success! 
        }, function(err) {
            // An error occured. Show a message to the user
        });
    };
    $scope.watchAcceleration = function () {
        var options = { frequency: 3000 };  // Update every 3 seconds

            $cordovaDeviceMotion.watchAcceleration(options).then(
            function(watchID) {
                // handle the watchID to use it with clearWatch()
            },  
            function(err) {},
            function(acceleration) {
            $cordovaDialogs.alert('Acceleration X: ' + acceleration.x + '\n' +
            'Acceleration Y: ' + acceleration.y + '\n' +
            'Acceleration Z: ' + acceleration.z + '\n' +
            'Timestamp: '      + acceleration.timestamp + '\n');
        });
    };
    $scope.clearWatch = function() {
            // use watchID from watchAccelaration()
        $cordovaDeviceMotion.clearWatch(watchID).then(function(result) {
            // Success! 
        }, function(err) {
            // An error occured. Show a message to the user
        });
    }
});
```
