### PR TITLE
SocialSharing plugin wrapper fixed and extended

### DIFF
--- a/src/plugins/socialSharing.js
+++ b/src/plugins/socialSharing.js
@@ -1,8 +1,6 @@
-// NOTE: shareViaSms -> access multiple numbers in a string like: '0612345678,0687654321'
 // NOTE: shareViaEmail -> if user cancels sharing email, success is still called
 // NOTE: shareViaEmail -> TO, CC, BCC must be an array, Files can be either null, string or array
 // TODO: add support for iPad
-// TODO: add support for Windows Phone
 // TODO: detailed docs for each social sharing types (each social platform has different requirements)
 
 angular.module('ngCordova.plugins.socialSharing', [])
@@ -10,9 +8,9 @@ angular.module('ngCordova.plugins.socialSharing', [])
   .factory('$cordovaSocialSharing', ['$q', function ($q) {
 
     return {
-      shareViaTwitter: function (message, image, link) {
+      share: function (message, subject, file, link) {
         var q = $q.defer();
-        window.plugins.socialsharing.shareViaTwitter(message, image, link,
+        window.plugins.socialsharing.share(message, subject, file, link,
           function () {
             q.resolve(true); // success
           },
@@ -22,9 +20,9 @@ angular.module('ngCordova.plugins.socialSharing', [])
         return q.promise;
       },
 
-      shareViaWhatsApp: function (message, image, link) {  // image ?? link ??
+      shareViaTwitter: function (message, file, link) {
         var q = $q.defer();
-        window.plugins.socialsharing.shareViaWhatsApp(message, image, link,
+        window.plugins.socialsharing.shareViaTwitter(message, file, link,
           function () {
             q.resolve(true); // success
           },
@@ -34,9 +32,9 @@ angular.module('ngCordova.plugins.socialSharing', [])
         return q.promise;
       },
 
-      shareViaFacebook: function (message, image, link) {  // image ?? link ??
+      shareViaWhatsApp: function (message, file, link) {
         var q = $q.defer();
-        window.plugins.socialsharing.shareViaFacebook(message, image, link,
+        window.plugins.socialsharing.shareViaWhatsApp(message, file, link,
           function () {
             q.resolve(true); // success
           },
@@ -46,9 +44,9 @@ angular.module('ngCordova.plugins.socialSharing', [])
         return q.promise;
       },
 
-      shareViaSMS: function (message, number) {
+      shareViaFacebook: function (message, file, link) {
         var q = $q.defer();
-        window.plugins.socialsharing.shareViaSMS(message, number,
+        window.plugins.socialsharing.shareViaFacebook(message, file, link,
           function () {
             q.resolve(true); // success
           },
@@ -58,9 +56,9 @@ angular.module('ngCordova.plugins.socialSharing', [])
         return q.promise;
       },
 
-      shareViaEmail: function (message, subject, toArr, ccArr, bccArr, file ) {
+      shareViaSMS: function (message, commaSeparatedPhoneNumbers) {
         var q = $q.defer();
-        window.plugins.socialsharing.shareViaEmail(message, number,
+        window.plugins.socialsharing.shareViaSMS(message, commaSeparatedPhoneNumbers,
           function () {
             q.resolve(true); // success
           },
@@ -70,15 +68,51 @@ angular.module('ngCordova.plugins.socialSharing', [])
         return q.promise;
       },
 
-      canShareVia: function (social, message, image, link) {
+      shareViaEmail: function (message, subject, toArr, ccArr, bccArr, fileArr) {
         var q = $q.defer();
-        window.plugins.socialsharing.canShareVia(social, message, image, link,
+        window.plugins.socialsharing.shareViaEmail(message, subject, toArr, ccArr, bccArr, fileArr,
+          function () {
+            q.resolve(true); // success
+          },
+          function () {
+            q.reject(false); // error
+          });
+        return q.promise;
+      },
+
+      canShareViaEmail: function () {
+        var q = $q.defer();
+        window.plugins.socialsharing.canShareViaEmail(
+            function () {
+              q.resolve(true); // success
+            },
+            function () {
+              q.reject(false); // error
+            });
+        return q.promise;
+      },
+
+      canShareVia: function (via, message, subject, file, link) {
+        var q = $q.defer();
+        window.plugins.socialsharing.canShareVia(via, message, subject, file, link,
           function (success) {
             q.resolve(success); // success
           },
           function (error) {
             q.reject(error); // error
           });
+        return q.promise;
+      },
+
+      shareVia: function (via, message, subject, file, link) {
+        var q = $q.defer();
+        window.plugins.socialsharing.shareVia(via, message, subject, file, link,
+            function () {
+              q.resolve(true); // success
+            },
+            function () {
+              q.reject(false); // error
+            });
         return q.promise;
       }
 


### PR DESCRIPTION
- Added the (most important) `share` function
- Renamed SMS phonenumber param to indicate you can pass multiple by separating by a comma
- Renamed all `image` params to `file`, because any file can be shared (or even a file array actually, most of the time)
- Fixed `shareViaEmail`, because it was an unadjusted copy-paste of `shareViaSMS`
- Added `shareVia`
- Added `canShareViaEmail`
- Fixed `canShareVia` (subject was missing)
- Removed some now obsolete TODO's/notes
