### PR TITLE
Fixing replaceBOOL argument init for backward compatibility

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -74,6 +74,7 @@ angular.module('ngCordova.plugins.file', [])
         // Backward compatibility for previous function createFile(dir, file, replaceBOOL)
         if (arguments.length == 3) {
             filePath = '/' + filePath + '/' + arguments[1];
+            replaceBOOL = arguments[2];
         }
 
         getFilesystem().then(


### PR DESCRIPTION
I have missed this replaceBOOL backward compatibility case, sorry !
