### PR TITLE
Added relative path and filename and fixes to createDir

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -202,7 +202,7 @@ angular.module('ngCordova.plugins.file', [])
         return q.promise;
       },
 
-        downloadFile: function (source, filePath, fileName, trustAllHosts, options) {
+        downloadFile: function (source, filePath, trustAllHosts, options) {
             var q = $q.defer();
             var fileTransfer = new FileTransfer();
             var uri = encodeURI(source);
@@ -210,24 +210,18 @@ angular.module('ngCordova.plugins.file', [])
             fileTransfer.onprogress = function(progressEvent) {
                 q.notify(progressEvent);
             };
-            getFilesystem().then(
-                function (filesystem) {
-                    filesystem.root.getDirectory(filePath, {create: true}, function(absolutePath) {
-                        fileTransfer.download(
-                            uri,
-                            absolutePath.toURL() + fileName,
-                            function (entry) {
-                                q.resolve(entry);
-                            },
-                            function (error) {
-                                q.reject(error);
-                            },
-                            trustAllHosts, options);
-                    }, function(error) {
-                        q.reject(error);
-                    });
-                }
-            );
+
+            fileTransfer.download(
+                uri,
+                filePath,
+                function (entry) {
+                    q.resolve(entry);
+                },
+                function (error) {
+                    q.reject(error);
+                },
+                trustAllHosts, options);
+
             return q.promise;
         },
 


### PR DESCRIPTION
The wrapper now has support for paths like /Android/data/com.bla/files/ then one can fill in any file name and download the file.
This makes it easier to use this wrapper in my opinion, since no path like, for instance  file:///storage/emulated/0/Android/data/com.ionicframework.starter/files/copy.doc has to be provided.

Also added a deferred object and promise return at the createDir function. According to the documentation the function should return a promise, but it did not. Now it does.
