### PR TITLE
readFileAbsolute and readFileMetadataAbsolute

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -189,6 +189,41 @@ angular.module('ngCordova.plugins.file', [])
 
         return q.promise;
       },
+      
+      readFileAbsolute: function (){
+        var q = $q.defer();
+        window.resolveLocalFileSystemURI(filePath, 
+          function (fileEntry) {
+            fileEntry.file(function(file) {
+              var reader = new FileReader();
+              reader.onloadend = function () {
+                q.resolve(this.result);
+              };
+
+              reader.readAsText(file);
+            })
+          },
+          function (error) {
+            q.reject(error);  
+          }
+        );
+      },
+      
+      readFileMetadataAbsolute: function (filePath){
+        var q = $q.defer();
+        window.resolveLocalFileSystemURI(filePath, 
+          function (fileEntry) {
+            fileEntry.file(function(file) {
+              q.resolve(file);
+            })
+          },
+          function (error) {
+            q.reject(error);  
+          }
+        );
+        
+        return q.promise;
+      },
 
       downloadFile: function (source, filePath, trustAllHosts, options) {
         var q = $q.defer();


### PR DESCRIPTION
readFileAbsolute and readFileMetadataAbsolute will provide exactly what readFile and readFileMetadata provides, except that they accept absolute file path locations (previous readFile and readFileMetadata methods only accepted relative file paths to which an absolute file path is added with filesystem.root).

Instead of using filesystem.root.getFile, we instead use window.resolveLocalFileSystemURI to resolve the absolute file path location's actual file using the provided absolute file path.

This is a cleaner implementation of pull request #153. Also, I cloned the repository with my changes to local environment. Ran karma and produced new minified JS files. You can see those changes here: https://github.com/alastairparagas/ng-cordova
