### PR TITLE
replacing window by $window

### DIFF
--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -1,10 +1,10 @@
 angular.module('ngCordova.plugins.push', [])
 
-.factory('$cordovaPush', ['$q', function ($q) {
+.factory('$cordovaPush', ['$q', '$window', function ($q, $window) {
     return {
         register: function (config) {
             var q = $q.defer();
-            window.plugins.pushNotification.register(
+            $window.plugins.pushNotification.register(
             function (result) {
                 q.resolve(result);
             },
@@ -18,7 +18,7 @@ angular.module('ngCordova.plugins.push', [])
         
         unregister: function (options) {
             var q = $q.defer();
-            window.plugins.pushNotification.unregister(
+            $window.plugins.pushNotification.unregister(
             function (result) {
                 q.resolve(result);
             },
@@ -33,7 +33,7 @@ angular.module('ngCordova.plugins.push', [])
         // iOS only
         setBadgeNumber: function(number) {
         	var q = $q.defer();
-            window.plugins.pushNotification.setApplicationIconBadgeNumber(
+            $window.plugins.pushNotification.setApplicationIconBadgeNumber(
             function (result) {
                 q.resolve(result);
             },


### PR DESCRIPTION
Injected $window in the service for replacing the reference to window global object.
$window is a reference to the browser's window object. While window is globally available in JavaScript, it causes testability problems, because it is a global variable. In angular we always refer to it through the $window service, so it may be overridden, removed or mocked for testing.
