### PR TITLE
Add timeout option to uploadFile

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -11,7 +11,7 @@
 angular.module('ngCordova.plugins.file', [])
 
 //Filesystem (checkDir, createDir, checkFile, creatFile, removeFile, writeFile, readFile)
-  .factory('$cordovaFile', ['$q', function ($q, $timeout) {
+  .factory('$cordovaFile', ['$q', '$timeout', function ($q, $timeout) {
 
     return {
       checkDir: function (dir) {


### PR DESCRIPTION
The native FileTransfer uploadFile does not have a timeout. Sometimes, this causes my users to be stuck at a waiting screen. The recommended method for a timeout that I have found is implemented in this pull request. I decided to go this route since "abort()" has not yet been implemented
