### PR TITLE
Fixed compass.clearWatch missing the watchID parameter

### DIFF
--- a/src/plugins/deviceOrientation.js
+++ b/src/plugins/deviceOrientation.js
@@ -29,7 +29,7 @@ angular.module('ngCordova.plugins.deviceOrientation', [])
       }
     },
     clearWatch: function(watchID) {
-      navigator.compass.clearWatch();
+      navigator.compass.clearWatch(watchID);
     }
   }
 }]);


### PR DESCRIPTION
$cordovaDeviceOrientation.clearWatch has a watchID parameter, but it wasn't used in the navigator.compass.clearWatch call.
