### PR TITLE
cordovaDialogs: Fallbacks added to javascript browser methods so it does...

### DIFF
--- a/src/plugins/dialogs.js
+++ b/src/plugins/dialogs.js
@@ -3,20 +3,51 @@ angular.module('ngCordova.plugins.dialogs', [])
 .factory('$cordovaDialogs', [function() {
 
   return {
+
     alert: function(message, callback, title, buttonName) {
-	    return navigator.notification.alert.apply(navigator.notification, arguments);
+
+			if(navigator.notification) {
+					return navigator.notification.alert.apply(navigator.notification, arguments);
+			}else{
+					// Fallbacks to window alert in browser
+					return window.alert(message);
+			}
+	    
     },
 
     confirm: function(message, callback, title, buttonName) {
-	    return navigator.notification.confirm.apply(navigator.notification, arguments);
+			
+			if(navigator.notification){
+					return navigator.notification.confirm.apply(navigator.notification, arguments);					
+			}else{
+					// Fallbacks to window confirm in browser
+					return window.confirm(message);
+			}
+
     },
 
     prompt: function(message, promptCallback, title, buttonLabels, defaultText) {
-	    return navigator.notification.prompt.apply(navigator.notification, arguments);
+			
+			if(navigator.notification){
+					return navigator.notification.prompt.apply(navigator.notification, arguments);
+			}else{
+					// Fallbacks to navigator prompt in browser
+					return window.prompt(message);
+			}
+	  
     },
 
     beep: function(times) {
-	    return navigator.notification.beep(times);
+			
+				if(navigator.notification){
+						return navigator.notification.beep(times);
+				}else{
+						// Just returns false as we can't fake beep in browser
+						return false;
+				}
+				
     }
-  }
+  
+	};
+
 }]);


### PR DESCRIPTION
I just added fallbacks to browser window methods in dialogs pluggin.
This way you can test basic functionality in browser during development without throwing errors.

Just made changes in src folder, didn't change anything in dist. So it would need to be added there.
