### PR TITLE
File callbacks

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -19,7 +19,7 @@ angular.module('ngCordova.plugins.file', [])
             filesystem.root.getDirectory(dir, {create: false},
               //Dir exists
               function (entry) {
-                q.resolve();
+                q.resolve(entry);
               },
               //Dir doesn't exist
               function (error_code) {


### PR DESCRIPTION
Since cordova plugin file changed handling paths (relatives) with v1.0.0 you cannot set absolute path yourself:

```
exec(win, fail, "File", "getDirectory", [this.toInternalURL(), path, options]);
```

where this.toInternalURL() set root of directories for you.
It is better return also entry back with promise. Then you can reuse entry (and get URL) out of the method with file-transfer plugin etc.. In error case the error code will be returned.
