### PR TITLE
Update splashscreen.js

### DIFF
--- a/src/plugins/splashscreen.js
+++ b/src/plugins/splashscreen.js
@@ -4,11 +4,13 @@ angular.module('ngCordova.plugins.splashscreen', [])
 
   return {
     hide: function () {
-      return navigator.splashscreen.hide();
+      if(navigator.splashscreen)
+        return navigator.splashscreen.hide();
     },
 
     show: function () {
-      return navigator.splashscreen.show();
+      if(navigator.splashscreen)
+        return navigator.splashscreen.show();
     }
   };
 


### PR DESCRIPTION
Checking navigator.splashscreen is not null to prevent console errors when testing in browser (not in device)
