### PR TITLE
Fix writeFile silent fail

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -163,9 +163,16 @@ angular.module('ngCordova.plugins.file', [])
                   },
                   function (error) {
                     q.reject(error);
-                  });
+                  }
+                );
+              },
+              function (error) {
+                q.reject(error);
               }
             );
+          },
+          function (error) {
+            q.reject(error);
           }
         );
 


### PR DESCRIPTION
`$cordovaFile.writeFile` was missing some error callback.
This was causing it to fail but give no feedback.
