### PR TITLE
fix($cordovaFacebookConnect): change provider name

### DIFF
--- a/src/plugins/facebookConnect.js
+++ b/src/plugins/facebookConnect.js
@@ -3,7 +3,7 @@
 
 'use strict';
 angular.module('ngCordova.plugins.facebookConnect', [])
-  .provider('$cordova', [
+  .provider('$cordovaFacebookConnectProvider', [
 
     function () {
       this.FacebookAppId = undefined;


### PR DESCRIPTION
In order to use a plugin specific provider name it has been changed to `$cordovaFacebookConnectProvider` as @programming-kid also mentioned it was intended.

---

**BREAKING CHANGE:** the facebookConnect provider name has been changed

To migrate the code follow the example below:

Before:

``` js
.config(['$cordovaProvider', function ($cordovaProvider) {
  $cordovaProvider.setFacebookAppId(12345);
}]);
```

After:

``` js
.config(['$cordovaFacebookConnectProvider', function ($cordovaFacebookConnectProvider) {
  $cordovaProvider.setFacebookAppId(12345);
}]);
```
