### PR TITLE
fix($cordovaSQLite): changing the parameters

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -6,13 +6,8 @@ angular.module('ngCordova.plugins.sqlite', [])
   .factory('$cordovaSQLite', ['$q', function ($q) {
 
     return  {
-      openDB: function (dbName) {
-        return  window.sqlitePlugin.openDatabase({name: dbName});
-      },
-
-
-      openDBBackground: function (dbName) {
-        return window.sqlitePlugin.openDatabase({name: dbName, bgType: 1});
+      openDB: function (dbObject) {
+        return  window.sqlitePlugin.openDatabase(dbObject);
       },
 
       execute: function (db, query, binding) {


### PR DESCRIPTION
**BREAKING CHANGE**: the api has changed

Follow these steps to migrate:

Before:

```
$cordovaSQLite.openDB('yourDBName')
$cordovaSQLite.openDBBackground('yourDBName')
```

After:

```
$cordovaSQLite.openDB({ name: 'yourDBName' })
$cordovaSQLite.openDB({ name: 'yourDBName', bgType: 1 })
```

Docs are updated soon

fixes #273
