### PR TITLE
chore(*): add coverage test

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -15,7 +15,16 @@ module.exports = {
   ,
 
   frameworks: ['jasmine'],
-  reporters: ['progress'],
+  reporters: ['progress', 'coverage'],
+  preprocessors: {
+    'src/plugins/*.js': ['coverage']
+  },
+
+  coverageReporter: {
+    type : 'html',
+    dir : 'coverage/'
+  },
+
   port: 9876,
   colors: true,
   // possible values: 'OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "gulp-jshint": "^1.6.1",
     "gulp-uglify": "^0.2.1",
     "minimist": "^0.1.0",
-    "jshint-stylish": "^0.4.0"
+    "jshint-stylish": "^0.4.0",
+    "karma-coverage": "~0.2.6"
   },
   "licenses": [
     {


### PR DESCRIPTION
For developers it's great to have an overview about the
current coverage of unit tests. This adds the `karma-coverage`
preprocessor. It never gets committed to the repo, because its already
ignored in the `.gitignore` file.
