### PR TITLE
improved error handling and refactored some common code in $cordovaFile

### DIFF
--- a/src/mocks/file.js
+++ b/src/mocks/file.js
@@ -5,23 +5,13 @@
  * @description
  * A service for testing interaction with device directories and files
  * in an app build with ngCordova.
- */
+ */ 
 ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 	var throwsError = false;
 	var fileSystem = {};
 
-	var mockIt = function(errorMessage) {
-		var defer = $q.defer();
-		if (this.throwsError) {
-			defer.reject(errorMessage);
-		} else {
-			defer.resolve();
-		}
-		return defer.promise;
-	};
-
 	return {
-    /**
+        /**
 		 * @ngdoc property
 		 * @name throwsError
 		 * @propertyOf ngCordovaMocks.cordovaFile
@@ -29,10 +19,10 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 		 * @description
 		 * A flag that signals whether a promise should be rejected or not.
 		 * This property should only be used in automated tests.
-		 **/
+		**/
 		throwsError: throwsError,
 
-    /**
+        /**
 		 * @ngdoc property
 		 * @name fileSystem
 		 * @propertyOf ngCordovaMocks.cordovaFile
@@ -40,75 +30,97 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 		 * @description
 		 * A fake, in-memory file system. This is incomplete at this time.
 		 * This property should only be used in automated tests.
-		 **/		
+		**/		
 		fileSystem: fileSystem,
 
 		checkDir: function(directory) {
-			return mockIt.call(this, 'There was an error checking the directory.');		
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error checking the directory.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		createDir: function(directory, overwrite) {
-			return mockIt.call(this, 'There was an error creating the directory.');		
-		},
-
-		listDir: function(filePath) {
-		 	return mockIt.call(this, 'There was an error listing the directory');
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error creating the directory.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		checkFile: function(directory, file) {
-			return mockIt.call(this, 'There was an error checking for the file.');	
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error checking for the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		createFile: function(directory, file, overwrite) {
-			return mockIt.call(this, 'There was an error creating the file.');
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error creating the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		removeFile: function(directory, file) {
-			return mockIt.call(this,'There was an error removng the file.');	
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error removng the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		writeFile: function(directory, file) {
-			return mockIt.call(this,'There was an error writing the file.');		
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error writing the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		readFile: function(directory, file) {
-			return mockIt.call(this, 'There was an error reading the file.');			
-		},
-
-		readAsText: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file as text.');
-		},
-
-		readAsDataURL: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file as a data url.');
-		},
-
-		readAsBinaryString: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file as a binary string.');
-		},
-
-		readAsArrayBuffer: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file as an array buffer.');
-		},
-
-		readFileMetadata: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file metadata');
-		},
-
-		readFileAbsolute: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file from the absolute path');
-		},
-
-		readFileMetadataAbsolute: function (filePath) {
-			return mockIt.call(this, 'There was an error reading the file metadta from the absolute path');
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error reading the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		downloadFile: function(source, filePath, trust, options) {
-			return mockIt.call(this, 'There was an error downloading the file.');	
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error downloading the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		},
 
 		uploadFile: function(server, filePath, options) {
-			return mockIt.call(this, 'There was an error uploading the file.');	
+			var defer = $q.defer();
+			if (this.throwsError) {
+				defer.reject('There was an error uploading the file.');
+			} else {
+				defer.resolve();
+			}
+			return defer.promise;			
 		}		
 	};
 }]);


### PR DESCRIPTION
This is a subset of the changes from PR #306, in particular:
1. Improved error handling in all `$cordovaFile` methods. Some of the file system api calls were being invoked without an error callback, which could cause the promise returned by the enclosing `$cordovaFile` method to hang and never get resolved (see #160).
2. Replaced `console.log` with injected `$log.log()` for consistency with angular dependency injection pattern. I wanted to change it to `$log.warn()`, since it is a warning logged from a deprecated method, but I didn't want to change the functionality of anything that wasn't a bug in this PR so I just left it.
3. Refactored some duplicate code into some reusable private functions.

All feedback & suggestions welcome!
