### PR TITLE
Moved the cordovaKeychain service to match the shazron/KeychainPlugin examples.

### DIFF
--- a/src/plugins/keychain.js
+++ b/src/plugins/keychain.js
@@ -5,11 +5,10 @@ angular.module('ngCordova.plugins.keychain', [])
 
   .factory('$cordovaKeychain', ['$q', function ($q) {
 
-    var kc = new Keychain();
-
     return {
       getForKey: function (key, serviceName) {
         var defer = $q.defer();
+        var kc = new Keychain();
 
         kc.getForKey(function (value) {
           defer.resolve(value);
@@ -22,6 +21,7 @@ angular.module('ngCordova.plugins.keychain', [])
 
       setForKey: function (key, serviceName, value) {
         var defer = $q.defer();
+        var kc = new Keychain();
 
         kc.setForKey(function () {
           defer.resolve();
@@ -34,6 +34,7 @@ angular.module('ngCordova.plugins.keychain', [])
 
       removeForKey: function (ey, serviceName) {
         var defer = $q.defer();
+        var kc = new Keychain();
 
         kc.removeForKey(function () {
           defer.resolve();


### PR DESCRIPTION
Not sure if other people ran into this, but adding $cordovaKeychain to a bare-bones Ionic app failed, causing an exception during bootstrapping "Keychain is not defined" due to the DI flow trying to initialize the service var kc. By moving the creation into the functions (as shown in the shazron/KeychainPlugin examples) its lazy initialized and addresses the problem. I have an alternate version I'm working on that swaps in the single kc on the $ionicPlatform.ready callback, but thought this was more straightforward behavior.
