### PR TITLE
Fixed error in the docs of the Media plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1228,7 +1228,7 @@ cordova plugin add org.apache.cordova.media
 ```
 
 ```javascript
-module.controller('MyCtrl', function($scope, $cordovaNetwork) {
+module.controller('MyCtrl', function($scope, $cordovaMedia) {
   	var src = "/src/audio.mp3";
   
   	var mediaSource = $cordovaMedia.newMedia(src)


### PR DESCRIPTION
Hi,

I found and fixed an error in the docs of the Media plugin, the dependency annotation of the example was incorrect.

I forgot to create a new branch, is it important?

Best regards 
