### PR TITLE
Adds the toggle() method for the flashlight plugin

### DIFF
--- a/src/plugins/flashlight.js
+++ b/src/plugins/flashlight.js
@@ -32,6 +32,16 @@ angular.module('ngCordova.plugins.flashlight', [])
           q.reject(error)
         });
         return q.promise;
+      },
+
+      toggle: function () {
+        var q = $q.defer();
+        $window.plugins.flashlight.toggle(function (response) {
+          q.resolve(response);
+        }, function (error) {
+          q.reject(error)
+        });
+        return q.promise;
       }
     }
   }]);


### PR DESCRIPTION
The flashlight plugin supports toggle() as an alternative to switchOn() and switchOff() methods, but it's missing in ngCordova. This pull request adds it.
