### PR TITLE
FacebookLib isn't at the root of the project any more

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -906,13 +906,13 @@ cordova -d plugin add https://github.com/phonegap/phonegap-facebook-plugin.git -
 
 android update project --subprojects --path "platforms/android" --target android-19 --library "CordovaLib"
 
-android update project --subprojects --path "platforms/android" --target android-19 --library "FacebookLib"
+android update project --subprojects --path "platforms/android" --target android-19 --library "com.phonegap.plugins.facebookconnect/FacebookLib"
 
 cd platforms/android/
 
 ant clean
 
-cd FacebookLib
+cd com.phonegap.plugins.facebookconnect/FacebookLib
 
 ant clean
 
@@ -923,7 +923,7 @@ open -e AndroidManifest.xml
 
 ant release
 
-cd ../../..
+cd ../../../..
 
 cordova build android
 ```


### PR DESCRIPTION
Adapting the commands to the new directory structure: com.phonegap.plugins.facebookconnect/FacebookLib instead of /FacebookLib
