### PR TITLE
Simplify promisification in facebook.js

### DIFF
--- a/src/plugins/facebook.js
+++ b/src/plugins/facebook.js
@@ -28,76 +28,42 @@ angular.module('ngCordova.plugins.facebook', [])
           this.init(this.getAppID());
 
           var q = $q.defer();
-          facebookConnectPlugin.login(permissions,
-            function (res) {
-              q.resolve(res);
-            }, function (res) {
-              q.reject(res);
-            });
+          facebookConnectPlugin.login(permissions, q.resolve, q.reject);
 
           return q.promise;
         },
 
         showDialog: function (options) {
-
           var q = $q.defer();
-          facebookConnectPlugin.showDialog(options,
-            function (res) {
-              q.resolve(res);
-            },
-            function (err) {
-              q.reject(err);
-            });
+          facebookConnectPlugin.showDialog(options, q.resolve, q.reject);
 
           return q.promise;
         },
 
         api: function (path, permissions) {
           var q = $q.defer();
-
-          facebookConnectPlugin.api(path, permissions,
-            function (res) {
-              q.resolve(res);
-            },
-            function (err) {
-              q.reject(err);
-            });
+          facebookConnectPlugin.api(path, permissions, q.resolve, q.reject);
 
           return q.promise;
         },
 
         getAccessToken: function () {
           var q = $q.defer();
-          facebookConnectPlugin.getAccessToken(function (res) {
-              q.resolve(res);
-            },
-            function (err) {
-              q.reject(err);
-            });
+          facebookConnectPlugin.getAccessToken(q.resolve, q.reject);
 
           return q.promise;
         },
 
         getLoginStatus: function () {
           var q = $q.defer();
-          facebookConnectPlugin.getLoginStatus(function (res) {
-              q.resolve(res);
-            },
-            function (err) {
-              q.reject(err);
-            });
+          facebookConnectPlugin.getLoginStatus(q.resolve, q.reject);
 
           return q.promise;
         },
 
         logout: function () {
           var q = $q.defer();
-          facebookConnectPlugin.logout(function (res) {
-              q.resolve(res);
-            },
-            function (err) {
-              q.reject(err);
-            });
+          facebookConnectPlugin.logout(q.resolve, q.reject);
 
           return q.promise;
         }


### PR DESCRIPTION
No need for the anonymous functions, just invoke the `q.reject`/`q.resolve` directly as the callback params.

Wanted to send this PR before I started doing it on the other plugins as well.

----

I just noticed this is actually the case for quite a lot of the plugins, what do you guys think about a little wrapper/decorator to `$q` which promisifies a callback-function.
See [Bluebird promisification](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisification) for an example.