### PR TITLE
Insert default options on datePicker

### DIFF
--- a/src/plugins/datepicker.js
+++ b/src/plugins/datepicker.js
@@ -4,6 +4,9 @@ angular.module('ngCordova.plugins.datePicker', [])
 
     return {
       show: function (options) {
+        options = options ||
+          {date: new Date(), mode: 'date'};
+          
         var d = $q.defer();
 
         $window.datePicker.show(options, function (date) {

--- a/test/plugins/datePicker.spec.js
+++ b/test/plugins/datePicker.spec.js
@@ -35,4 +35,26 @@ describe('Service: $cordovaDatePicker', function() {
     expect(window.datePicker.show.calls[0].args[0]).toBe(options);
   });
 
+  it('should have default options if none are passed', function() {
+    var result;
+
+    spyOn(window.datePicker, 'show')
+      .andCallFake(function(date, successCb, errorCb) {
+        successCb(date);
+      });
+
+    $cordovaDatePicker
+      .show()
+      .then(function (response) {
+        result = response;
+      });
+
+      $rootScope.$digest();
+
+      console.log(result);
+
+      expect(result.date).not.toBe(undefined);
+      expect(result.mode).toBe('date');
+  });
+
 });


### PR DESCRIPTION
This is more a personal preference, you may not like default options, but if you think about this concrete use case, it makes sense. Always when we work with dates, we normally end using `new Date()` by default.

I think it is a good idea to provide that default here because I think that the most common use is that one.

What do you think? That would need an update on the docs but since it is another branch, I don't think I can do that at once.

EDIT: Forgot we like tests as well, if you like the idea, I will create a new test :)
