### PR TITLE
pushPlugin (fix): wrapping $broadcast in an $apply() statement scope fix

### DIFF
--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -6,7 +6,9 @@ angular.module('ngCordova.plugins.push', [])
   .factory('$cordovaPush', ['$q', '$window', '$rootScope', function ($q, $window, $rootScope) {
     return {
       onNotification: function(notification) {
-        $rootScope.$broadcast('pushNotificationReceived', notification);
+        $rootScope.$apply(function () {
+          $rootScope.$broadcast('pushNotificationReceived', notification);
+        });
       },
 
       register: function (config) {


### PR DESCRIPTION
Myself and others noticed with my previous pull request that the notification payload would not update scope, for instance if you used it to do something similar to this:

``` javascript
myApp.controller(function($scope) {
  $scope.messageArray = [];

  $scope.$on('pushNotificationReceived', function(event, notification) {
    $scope.messageArray.push(notification.payload);
  });
});
```

and had the messageArray ng-repeated in html.

This is (I think) because the notification is coming from outside of Angular - from cordova to be more precise - and without this extra code the digest would never happen to update bindings/watches.

Please also note I did not run `gulp`, I noticed that it would bring in some other code not related to my fix.
