### PR TITLE
add httpd plugin to embed nano web server into cordova app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ bower install ngCordova
 - [Geolocation](https://github.com/apache/cordova-plugin-geolocation) *
 - [Globalization](https://github.com/apache/cordova-plugin-globalization) *
 - [Google Analytics](https://github.com/phonegap-build/GAPlugin)
+- [Httpd (Web Server)](https://github.com/floatinghotpot/cordova-httpd)
 - [InAppBrowser](https://github.com/apache/cordova-plugin-inappbrowser)*
 - [Keyboard](https://github.com/driftyco/ionic-plugins-keyboard)
 - [Keychain](https://github.com/shazron/KeychainPlugin)

--- a/src/plugins/httpd.js
+++ b/src/plugins/httpd.js
@@ -1,0 +1,57 @@
+// install  :     cordova plugin add https://github.com/floatinghotpot/cordova-httpd.git
+// link     :     https://github.com/floatinghotpot/cordova-httpd
+
+angular.module('ngCordova.plugins.httpd', [])
+	.factory('$cordovaHttpd', [ '$q', '$window', function($q, $window) {
+
+	return {
+		startServer : function(options) {
+			var d = $q.defer();
+
+			cordova.plugins.CorHttpd.startServer(options, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		stopServer : function() {
+			var d = $q.defer();
+
+			cordova.plugins.CorHttpd.stopServer(function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		getURL : function() {
+			var d = $q.defer();
+
+			cordova.plugins.CorHttpd.getURL(function(url) {
+				d.resolve(url);
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		getLocalPath : function() {
+			var d = $q.defer();
+
+			cordova.plugins.CorHttpd.getLocalPath(function(path) {
+				d.resolve(path);
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		}
+
+	};
+} ]);

--- a/src/plugins/module.js
+++ b/src/plugins/module.js
@@ -26,6 +26,7 @@ angular.module('ngCordova.plugins', [
   'ngCordova.plugins.globalization',
   'ngCordova.plugins.googleAnalytics',
   'ngCordova.plugins.googleMap',
+  'ngCordova.plugins.httpd',
   'ngCordova.plugins.inAppBrowser',
   'ngCordova.plugins.keyboard',
   'ngCordova.plugins.keychain',


### PR DESCRIPTION
Embed nano web server into Cordova App.

Supported platform:
＊ iOS
＊ Android

You can browse (locally or remotely) to access files in android/ios phone/pad:
＊ browse the files in mobile device with a browser in PC.
＊ copy files from mobile device to PC quickly, just with Wifi.
＊ use Cordova webview to access the assets/www/ content with http protocol.

Why http access is good?
＊ Use wifi instead of cable, more convenient.
＊ For security reason, browser does not support local AJAX calls. It's big bottle neck to deploy HTML5 games to Cordova platform.
＊ The most popular phaser.js game engine, a httpd is always required, as it use AJAX to load resource.

This plugin is being used by the famous Meteor project.
