### PR TITLE
add plugin for Google Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ bower install ngCordova
 ```
 
 ## Plugins
-- [AdMob](https://github.com/floatinghotpot/cordova-admob-pro)
+- [AdMob](https://github.com/floatinghotpot/cordova-plugin-admob)
 - [App Availability](https://github.com/ohh2ahh/AppAvailability)
 - [App Prefences](https://github.com/dferrell/plugins-application-preferences)
 - [App Rate](https://github.com/pushandplay/cordova-plugin-apprate)
@@ -51,6 +51,7 @@ $ bower install ngCordova
 - [Flashlight](https://github.com/EddyVerbruggen/Flashlight-PhoneGap-Plugin)
 - [Geolocation](https://github.com/apache/cordova-plugin-geolocation) *
 - [Globalization](https://github.com/apache/cordova-plugin-globalization) *
+- [Google Ads](https://github.com/floatinghotpot/cordova-admob-pro)
 - [Google Analytics](https://github.com/phonegap-build/GAPlugin)
 - [Httpd (Web Server)](https://github.com/floatinghotpot/cordova-httpd)
 - [InAppBrowser](https://github.com/apache/cordova-plugin-inappbrowser)*

--- a/src/plugins/googleAds.js
+++ b/src/plugins/googleAds.js
@@ -1,0 +1,104 @@
+// install  :     cordova plugin add https://github.com/floatinghotpot/cordova-admob-pro.git
+// link     :     https://github.com/floatinghotpot/cordova-admob-pro
+
+angular.module('ngCordova.plugins.googleAds', [])
+	.factory('$cordovaGoogleAds', [ '$q', '$window', function($q, $window) {
+
+	return {
+		setOptions : function(options) {
+			var d = $q.defer();
+
+			$window.AdMob.setOptions(options, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		createBanner : function(options) {
+			var d = $q.defer();
+
+			$window.AdMob.createBanner(options, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		removeBanner : function() {
+			var d = $q.defer();
+
+			$window.AdMob.removeBanner(function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		showBanner : function(position) {
+			var d = $q.defer();
+
+			$window.AdMob.showBanner(position, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		showBannerAtXY : function(x, y) {
+			var d = $q.defer();
+
+			$window.AdMob.showBannerAtXY(x, y, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		hideBanner : function() {
+			var d = $q.defer();
+
+			$window.AdMob.hideBanner(function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		prepareInterstitial : function(options) {
+			var d = $q.defer();
+
+			$window.AdMob.prepareInterstitial(options, function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		},
+
+		showInterstitial : function() {
+			var d = $q.defer();
+
+			$window.AdMob.showInterstitial(function() {
+				d.resolve();
+			}, function() {
+				d.reject();
+			});
+
+			return d.promise;
+		}
+	};
+} ]);

--- a/src/plugins/module.js
+++ b/src/plugins/module.js
@@ -24,6 +24,7 @@ angular.module('ngCordova.plugins', [
   'ngCordova.plugins.ga',
   'ngCordova.plugins.geolocation',
   'ngCordova.plugins.globalization',
+  'ngCordova.plugins.googleAds',
   'ngCordova.plugins.googleAnalytics',
   'ngCordova.plugins.googleMap',
   'ngCordova.plugins.httpd',


### PR DESCRIPTION
Add plugin for google ads, including AdMob and DoubleClick, and also support mediation to other Ad networks.

Supporting iOS, Android and Windows Phone.

The plugin is now published with source code and free to use and fork, but additional service is not free (need a license to get email/online support, additional payment for customization or new feature).
