### PR TITLE
Add keyboard mock

### DIFF
--- a/src/mocks/keyboard.js
+++ b/src/mocks/keyboard.js
@@ -1,0 +1,32 @@
+/**
+ * @ngdoc service
+ * @name ngCordovaMocks.cordovaKeyboard
+ *
+ * @description
+ * A service for testing device keyboard features
+ * in an app build with ngCordova.
+**/ 
+ngCordovaMocks.factory('$cordovaKeyboard', function() {
+  var isVisible=false;
+	
+	return {
+    hideAccessoryBar: function (bool) {
+    },
+
+    close: function () {
+      isVisible = false;
+    },
+
+    show: function () {
+      isVisible = true;
+    },
+
+    disableScroll: function (bool) {
+    },
+   
+    isVisible: function () {
+      return isVisible;
+    }
+
+	};
+});


### PR DESCRIPTION
Allows to test cordova app in browser without generating errors on `$cordovaKeyboard` use.
