### PR TITLE
Fix: subscribe callback is only called once

### DIFF
--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -117,7 +117,7 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       subscribe: function (delimiter) {
         var q = $q.defer();
         $window.bluetoothSerial.subscribe(delimiter, function (data) {
-          q.resolve(data);
+          q.notify(data);
         }, function (error) {
           q.reject(error);
         });
@@ -127,7 +127,7 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       subscribeRawData: function () {
         var q = $q.defer();
         $window.bluetoothSerial.subscribeRawData(function (data) {
-          q.resolve(data);
+          q.notify(data);
         }, function (error) {
           q.reject(error);
         });


### PR DESCRIPTION
The success callback for the subscribe calls are long running callbacks.

While subscribing with `\r\n` as the delimiter; when the device sends the data `hello\r\nworld`, I will only be able to receive `hello`.

This fix changes the `subscribe` and `subscribeRawData` API. Instead of doing:

``` javascript
$bluetoothSerial.
  subscribe().
  then(function (line) {
    doSomethingWith(line);
  });
```

It would now be:

``` javascript
$bluetoothSerial.
  subscribe().
  then(null, null, function (line) {
    doSomethingWith(line);
  });
```
