### PR TITLE
Possiblity to mock files/directories and file content

### DIFF
--- a/src/mocks/file.js
+++ b/src/mocks/file.js
@@ -71,7 +71,6 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 
         checkDir: function(directory) {
             if(this.shouldMockFiles){
-
                 var defer = $q.defer();
                 if(this.files[directory] && !this.files[directory].isFile){
                     defer.resolve();
@@ -92,7 +91,6 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
                 defer.resolve();
                 return defer.promise;
             }
-
             return mockIt.call(this, 'There was an error creating the directory.');
         },
 

--- a/test/mocks/file.spec.js
+++ b/test/mocks/file.spec.js
@@ -21,8 +21,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(true); },
 					function() { expect(false).toBe(true); }
 				)
-				.finally(function() { done(); })
-			;
+				.finally(done);
 
 			$rootScope.$digest();
 		});
@@ -34,7 +33,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(false); },
 					function() { expect(true).toBe(true); }
 				)
-				.finally(function() { done(); })
+				.finally(done);
 			;
 
 			$rootScope.$digest();
@@ -46,8 +45,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(true); },
 					function() { expect(false).toBe(true); }
 				)
-				.finally(function() { done(); })
-			;
+				.finally(done);
 
 			$rootScope.$digest();
 		});
@@ -59,8 +57,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(false); },
 					function() { expect(true).toBe(true); }
 				)
-				.finally(function() { done(); })
-			;
+				.finally(done);
 
 			$rootScope.$digest();
 		});	
@@ -71,8 +68,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(true); },
 					function() { expect(false).toBe(true); }
 				)
-				.finally(function() { done(); })
-			;
+				.finally(done);
 
 			$rootScope.$digest();
 		});
@@ -84,8 +80,7 @@ describe('ngCordovaMocks', function() {
 					function() { expect(true).toBe(false); },
 					function() { expect(true).toBe(true); }
 				)
-				.finally(function() { done(); })
-			;
+				.finally(done);
 
 			$rootScope.$digest();
 		});


### PR DESCRIPTION
Added possibility to mock files/directories as well as file content.  This makes it possible to test cases where one expect a file to exist on the device. Earlier this was not possible as the readFile/readAsText always would return undefined, this would break any app that expects a file to actually have content. 

This PR should be backward compatible as all new functionality needs "shouldMockFiles" flag to be set(this is false by default).
