### PR TITLE
feat($cordovaGeolocation): watchPosition promise

### DIFF
--- a/src/plugins/geolocation.js
+++ b/src/plugins/geolocation.js
@@ -21,7 +21,7 @@ angular.module('ngCordova.plugins.geolocation', [])
       watchPosition: function (options) {
         var q = $q.defer();
 
-        var watchId = navigator.geolocation.watchPosition(function (result) {
+        var watchID = navigator.geolocation.watchPosition(function (result) {
           // Do any magic you need
           q.notify(result);
 
@@ -29,10 +29,17 @@ angular.module('ngCordova.plugins.geolocation', [])
           q.reject(err);
         }, options);
 
-        return {
-          watchId: watchId,
-          promise: q.promise
+        q.promise.cancel = function() {
+          navigator.geolocation.clearWatch(watchID);
         };
+
+        q.promise.clearWatch = function(id) {
+          navigator.geolocation.clearWatch(id || watchID);
+        };
+
+        q.promise.watchID = watchID;
+
+        return q.promise;
       },
 
       clearWatch: function (watchID) {


### PR DESCRIPTION
this is a much better API and similar to <code>$http</code> mutating their promise 
https://github.com/angular/angular.js/blob/b3dfb3835923c9a941f63aa8f709760fd087962a/src/ng/http.js#L796

``` javascript
var watch_geo = $cordovaGeolocation.watchPosition();

watch_geo.then(angular.noop, failFunc, function(location) {
  console.log(location);
  sendBeacon(location);
});

watch_geo.cancel();
// or
watch_geo.clearWatch();
```

(The docs also need to be changed. I'm editing this PR github but I can update it in a bit)
