### PR TITLE
Add AppRate to module.js

### DIFF
--- a/src/plugins/module.js
+++ b/src/plugins/module.js
@@ -1,6 +1,7 @@
 angular.module('ngCordova.plugins', [
   'ngCordova.plugins.adMob',
   'ngCordova.plugins.appAvailability',
+  'ngCordova.plugins.AppRate',
   'ngCordova.plugins.backgroundGeolocation',
   'ngCordova.plugins.badge',
   'ngCordova.plugins.barcodeScanner',


### PR DESCRIPTION
AppRate was announced with 0.1.8alpha but does currently not work after
bower install, because it is not listed in module.js.
