### PR TITLE
Checks if keychain exists before instantiating

### DIFF
--- a/src/plugins/keychain.js
+++ b/src/plugins/keychain.js
@@ -3,9 +3,11 @@
 
 angular.module('ngCordova.plugins.keychain', [])
 
-  .factory('$cordovaKeychain', ['$q', function ($q) {
+  .factory('$cordovaKeychain', ['$q', '$window', function ($q, $window) {
 
-    var kc = new Keychain();
+    if ('Keychain' in $window) {
+      var kc = new Keychain();
+    }
 
     return {
       getForKey: function (key, serviceName) {


### PR DESCRIPTION
Make sure cordova Keychain is present on windows object before making
an instance of it to prevent the issue where injecting the plugin
throws an error.

Closes #499
