### PR TITLE
Bugfix: registering localNotifications callbacks

### DIFF
--- a/src/plugins/localNotification.js
+++ b/src/plugins/localNotification.js
@@ -106,20 +106,20 @@ angular.module('ngCordova.plugins.localNotification', [])
         $window.plugin.notification.local.setDefaults(Object);
       },
 
-      onadd: function () {
-        return $window.plugin.notification.local.onadd;
+      onAdd: function (callback) {
+        $window.plugin.notification.local.onadd = callback;
       },
 
-      ontrigger: function () {
-        return $window.plugin.notification.local.ontrigger;
+      onTrigger: function (callback) {
+        $window.plugin.notification.local.ontrigger = callback;
       },
 
-      onclick: function () {
-        return $window.plugin.notification.local.onclick;
+      onClick: function (callback) {
+        $window.plugin.notification.local.onclick = callback;
       },
 
-      oncancel: function () {
-        return $window.plugin.notification.local.oncancel;
+      onCancel: function (callback) {
+        $window.plugin.notification.local.oncancel = callback;
       }
     };
   }]);


### PR DESCRIPTION
The functions for registering callbacks on local notification interactions didn't work (as described in the docs). 

Changed the signature to allow passing in a callback:

`$cordovaLocalNotification.onClick(function (id, state, json) { console.log("pwnies!"); });`

Also changed capitalization of the functions for consistency. This works fine.

Note: I didn't update the docs and the onCancel callback doesn't seem to be called on cancel (Android), but that's probably some other bug.
