### PR TITLE
Fix the $cordovaLocalNotification events handling that wasn't work at al...

### DIFF
--- a/src/plugins/localNotification.js
+++ b/src/plugins/localNotification.js
@@ -19,7 +19,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.cancel: function (id, scope) {
+    cordovaLocalNotification.cancel = function (id, scope) {
       var q = $q.defer();
       $window.plugin.notification.local.cancel(
         id, function (result) {
@@ -29,7 +29,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.cancelAll: function (scope) {
+    cordovaLocalNotification.cancelAll = function (scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.cancelAll(
@@ -40,7 +40,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.isScheduled: function (id, scope) {
+    cordovaLocalNotification.isScheduled = function (id, scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.isScheduled(
@@ -52,7 +52,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.hasPermission: function (scope) {
+    cordovaLocalNotification.hasPermission = function (scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.hasPermission(
@@ -63,11 +63,11 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.promptForPermission: function () {
+    cordovaLocalNotification.promptForPermission = function () {
       $window.plugin.notification.local.promptForPermission();
     };
 
-    cordovaLocalNotification.getScheduledIds: function (scope) {
+    cordovaLocalNotification.getScheduledIds = function (scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.getScheduledIds(
@@ -78,7 +78,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.isTriggered: function (id, scope) {
+    cordovaLocalNotification.isTriggered = function (id, scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.isTriggered(
@@ -89,7 +89,7 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.getTriggeredIds: function (scope) {
+    cordovaLocalNotification.getTriggeredIds = function (scope) {
       var q = $q.defer();
 
       $window.plugin.notification.local.getTriggeredIds(
@@ -100,30 +100,30 @@ angular.module('ngCordova.plugins.localNotification', [])
       return q.promise;
     };
 
-    cordovaLocalNotification.getDefaults: function () {
+    cordovaLocalNotification.getDefaults = function () {
       return $window.plugin.notification.local.getDefaults();
     };
 
-    cordovaLocalNotification.setDefaults: function (Object) {
+    cordovaLocalNotification.setDefaults = function (Object) {
       $window.plugin.notification.local.setDefaults(Object);
     };
 
-    cordovaLocalNotification.onadd: function (fn) {
+    cordovaLocalNotification.onadd = function (fn) {
       $window.plugin.notification.local.onadd = fn;
       return cordovaLocalNotification;
     };
 
-    cordovaLocalNotification.ontrigger: function (fn) {
+    cordovaLocalNotification.ontrigger = function (fn) {
       $window.plugin.notification.local.ontrigger = fn;
       return cordovaLocalNotification;
     };
 
-    cordovaLocalNotification.onclick: function (fn) {
+    cordovaLocalNotification.onclick = function (fn) {
       $window.plugin.notification.local.onclick = fn;
       return cordovaLocalNotification;
     };
 
-    cordovaLocalNotification.oncancel: function (fn) {
+    cordovaLocalNotification.oncancel = function (fn) {
       $window.plugin.notification.local.oncancel = fn;
       return cordovaLocalNotification;
     };


### PR DESCRIPTION
...l;

This PR fix the issue https://github.com/driftyco/ng-cordova/issues/310.

The folowwing methods are wrapper that must handle the events for the local notifcations :

``` javascript
    $cordovaLocalNotification.onadd()

    $cordovaLocalNotification.ontrigger()

    $cordovaLocalNotification.onclick()

    $cordovaLocalNotification.oncancel()
```

The previous code just returned the reference to the event property of the plugin :

``` javascript
    onclick: function () {
        return $window.plugin.notification.local.onclick;
    },
```

Causing no way to use the method to assign a callback function.

So I refactored the four methods to get a function `fn` in argument and assign it to the plugin event property.

Plus, I rewriten the design of the module defining on top an object `cordovaLocalNotification`, attaching method's service to it  and returning it at the end. 

Thus, each "event handler" can assign its callback then returning the factory instance and so  we can use and chain these methods like this :

``` javascript
  $cordovaLocalNotification
    .onadd(_onAdd)
    .ontrigger(_onTrigger)
    .onclick(_onClick)
    .oncancel(_onCancel);

  function _onAdd(id, state, json){
    // ...
  }
  function _onTrigger(id, state, json){
    // ...
  }
  function _onClick(id, state, json){
    // ...
  }
  function _onCancel(id, state, json){
    // ...
  }
```
