### PR TITLE
fix: correct language and locale responses

### DIFF
--- a/src/mocks/globalization.js
+++ b/src/mocks/globalization.js
@@ -8,9 +8,10 @@
  */ 
 ngCordovaMocks.factory('$cordovaGlobalization', ['$q', function($q) {
 	var throwsError = false;
-	var preferredLanguage = 'en';
+    var languages = (navigator.languages) ?  navigator.languages : ["en-US", "en"];
+	var preferredLanguage = {value: languages[0]};
 	var firstDayOfWeek = 'Sunday';
-	var localeName = '';
+	var localeName = {value: languages[0]};
 
 	return {
         /**

--- a/src/mocks/globalization.js
+++ b/src/mocks/globalization.js
@@ -8,10 +8,10 @@
  */ 
 ngCordovaMocks.factory('$cordovaGlobalization', ['$q', function($q) {
 	var throwsError = false;
-    var languages = (navigator.languages) ?  navigator.languages : ["en-US", "en"];
-	var preferredLanguage = {value: languages[0]};
+    var language = (navigator.language) ?  navigator.language : "en-US";
+	var preferredLanguage = {value: language};
 	var firstDayOfWeek = 'Sunday';
-	var localeName = {value: languages[0]};
+	var localeName = {value: language};
 
 	return {
         /**

--- a/test/mocks/globalization.spec.js
+++ b/test/mocks/globalization.spec.js
@@ -13,12 +13,14 @@ describe('ngCordovaMocks', function() {
 		}));
 
 		it('should get the preferred language', function (done) {
-			var expected = 'English';
-			$cordovaGlobalization.preferredLanguage = expected;
-
 			$cordovaGlobalization.getPreferredLanguage()
 				.then(
-					function(actual) { expect(actual).toBe(expected); },
+					function(actual) {
+                        expect(typeof actual).toBe('object');
+                        expect(actual.value).toBeDefined();
+                        expect(typeof actual.value).toBe('string');
+                        expect(actual.value.length > 0).toBe(true);
+                    },
 					function() { expect(false).toBe(true); }
 				)
 				.finally(function() { done(); })
@@ -41,12 +43,15 @@ describe('ngCordovaMocks', function() {
 		});
 
 		it('should get the locale', function (done) {
-			var expected = 'EN';
-			$cordovaGlobalization.localeName = expected;
-
 			$cordovaGlobalization.getLocaleName()
 				.then(
-					function(actual) { expect(actual).toBe(expected); },
+					function(actual) {
+                        expect(actual).toBeDefined();
+                        expect(typeof actual).toBe('object');
+                        expect(actual.value).toBeDefined();
+                        expect(typeof actual.value).toBe('string');
+                        expect(actual.value.length > 0).toBe(true);
+                    },
 					function() { expect(false).toBe(true); }
 				)
 				.finally(function() { done(); })


### PR DESCRIPTION
Cordova always responds with object : {"value":"en-US"}
Updated tests to use actual results of query instead of hardcoded values.  Tests are copied from the cordova-plugin-globalization tests.

Signed-off-by: Justin Noel <justin.noel@calendee.com>