### PR TITLE
Changed the datepicker mock to return a promise as real one does.

### DIFF
--- a/src/mocks/datePicker.js
+++ b/src/mocks/datePicker.js
@@ -6,10 +6,13 @@
  * A service for testing datepicker features
  * in an app build with ngCordova.
  */
-ngCordovaMocks.factory('$cordovaDatePicker', function () {
+ngCordovaMocks.factory('$cordovaDatePicker', function ($q) {
   return {
-    show: function (options, fn) {
-      return options.date;
+    show: function (options) {
+      var q = $q.defer();
+      options = options || {date: new Date(), mode: 'date'};
+      q.resolve(options.date);
+      return q.promise;
     }
   };
 });

--- a/test/mocks/datePicker.spec.js
+++ b/test/mocks/datePicker.spec.js
@@ -4,19 +4,45 @@ describe('ngCordovaMocks', function () {
   });
 
   describe('cordovaDatePicker', function () {
-    var $cordovaDatePicker = null;
+    var $cordovaDatePicker = null,
+        $rootScope = null;
 
-    beforeEach(inject(function (_$cordovaDatePicker_) {
+    beforeEach(inject(function (_$cordovaDatePicker_, _$rootScope_) {
       $cordovaDatePicker = _$cordovaDatePicker_;
+      $rootScope = _$rootScope_;
     }));
 
     it('should show a date picker', function () {
-      var dummyDate = new Date(),
-          config = {
+      var result,
+          dummyDate = new Date(),
+          options = {
             date: dummyDate,
             mode: 'date'
           };
-      expect($cordovaDatePicker.show(config, function (date) {})).toBe(dummyDate);
+
+      $cordovaDatePicker
+        .show(options)
+        .then(function (response) {
+          result = response;
+        });
+
+      $rootScope.$digest();
+
+      expect(result).toBe(dummyDate);
+    });
+
+    it('should have default options if none are passed', function() {
+      var result;
+
+      $cordovaDatePicker
+        .show()
+        .then(function (response) {
+          result = response;
+        });
+
+      $rootScope.$digest();
+
+      expect(result instanceof Date).toBeTruthy();
     });
 
   });

--- a/test/plugins/datePicker.spec.js
+++ b/test/plugins/datePicker.spec.js
@@ -19,7 +19,7 @@ describe('Service: $cordovaDatePicker', function() {
     var options = { mode: 'date', date: new Date() };
 
     spyOn(window.datePicker, 'show')
-      .andCallFake(function (date, successCb, errorCb) {
+      .andCallFake(function (options, successCb, errorCb) {
         successCb(options.date);
       });
 
@@ -39,8 +39,8 @@ describe('Service: $cordovaDatePicker', function() {
     var result;
 
     spyOn(window.datePicker, 'show')
-      .andCallFake(function(date, successCb, errorCb) {
-        successCb(date);
+      .andCallFake(function(options, successCb, errorCb) {
+        successCb(options.date);
       });
 
     $cordovaDatePicker
@@ -53,8 +53,7 @@ describe('Service: $cordovaDatePicker', function() {
 
       console.log(result);
 
-      expect(result.date).not.toBe(undefined);
-      expect(result.mode).toBe('date');
+      expect(result instanceof Date).toBeTruthy();
   });
 
 });


### PR DESCRIPTION
I've changed the date picker mock to return a promise as the real one does and I've added the option to call the mock without arguments and modified the associate tests as usual.

In the process I've realized the test for the real $cordovaDatePicker without arguments was incorrect, nonetheless still green since the cordova plugin was also mocked incorrectly.