### PR TITLE
feat(plugin:file): more reading methods from an absolute path

### DIFF
--- a/src/mocks/file.js
+++ b/src/mocks/file.js
@@ -42,7 +42,7 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 		 * @description
 		 * A fake, in-memory file system. This is incomplete at this time.
 		 * This property should only be used in automated tests.
-		 **/		
+		 **/
 		fileSystem: fileSystem,
 
         /**
@@ -128,7 +128,7 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
         },
 
 		removeFile: function(directory, file) {
-			return mockIt.call(this,'There was an error removng the file.');	
+			return mockIt.call(this,'There was an error removing the file.');
 		},
 
         writeFile: function(filePath,data,options) {
@@ -179,16 +179,32 @@ ngCordovaMocks.factory('$cordovaFile', ['$q', function($q) {
 			return mockIt.call(this, 'There was an error reading the file from the absolute path');
 		},
 
+    readAbsoluteAsText: function (filePath) {
+      return mockIt.call(this, 'There was an error reading the file as a text from the absolute path');
+    },
+
+    readAbsoluteAsDataURL: function (filePath) {
+      return mockIt.call(this, 'There was an error reading the file as a data url from the absolute path');
+    },
+
+    readAbsoluteAsBinaryString: function (filePath) {
+      return mockIt.call(this, 'There was an error reading the file as a binary string from the absolute path');
+    },
+
+    readAbsoluteAsArrayBuffer: function (filePath) {
+      return mockIt.call(this, 'There was an error reading the file as an array buffer from the absolute path');
+    },
+
 		readFileMetadataAbsolute: function (filePath) {
 			return mockIt.call(this, 'There was an error reading the file metadta from the absolute path');
 		},
 
 		downloadFile: function(source, filePath, trust, options) {
-			return mockIt.call(this, 'There was an error downloading the file.');	
+			return mockIt.call(this, 'There was an error downloading the file.');
 		},
 
 		uploadFile: function(server, filePath, options) {
-			return mockIt.call(this, 'There was an error uploading the file.');	
-		}		
+			return mockIt.call(this, 'There was an error uploading the file.');
+		}
 	};
 }]);

--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -162,10 +162,39 @@ angular.module('ngCordova.plugins.file', [])
         return getFile(filePath, {create: false});
       },
 
-      readFileAbsolute: function (filePath) {
+      readFileAbsolute: function (filePath) {  /// now deprecated in new ng-cordova version
+        $log.log('readFileAbsolute is now deprecated, use readAbsoluteAsText instead');
+        return this.readAbsoluteAsText(filePath);
+      },
+
+      readAbsoluteAsText: function (filePath) {
         var q = $q.defer();
         getAbsoluteFile(filePath).then(function (file) {
           getPromisedFileReader(q).readAsText(file);
+        }, q.reject);
+        return q.promise;
+      },
+
+      readAbsoluteAsDataURL: function (filePath) {
+        var q = $q.defer();
+        getAbsoluteFile(filePath).then(function (file) {
+          getPromisedFileReader(q).readAsDataURL(file);
+        }, q.reject);
+        return q.promise;
+      },
+
+      readAbsoluteAsBinaryString: function (filePath) {
+        var q = $q.defer();
+        getAbsoluteFile(filePath).then(function (file) {
+          getPromisedFileReader(q).readAsBinaryString(file);
+        }, q.reject);
+        return q.promise;
+      },
+
+      readAbsoluteAsArrayBuffer: function (filePath) {
+        var q = $q.defer();
+        getAbsoluteFile(filePath).then(function (file) {
+          getPromisedFileReader(q).readAsArrayBuffer(file);
         }, q.reject);
         return q.promise;
       },


### PR DESCRIPTION
The only option to read a file from an absolute path, was to read it as a text. I added some more, as it is already done in the readAs* methods.

The use case where I found the additional methods might be required was when using the Image Picker plugin (together with the ng-cordova wrapper), that returns the absolute path to the selected files. I needed to transform files to base64, but the only option available was to read the files as text.