### PR TITLE
Fix keychain

### DIFF
--- a/src/plugins/keychain.js
+++ b/src/plugins/keychain.js
@@ -3,15 +3,12 @@
 
 angular.module('ngCordova.plugins.keychain', [])
 
-  .factory('$cordovaKeychain', ['$q', '$window', function ($q, $window) {
-
-    if ('Keychain' in $window) {
-      var kc = new Keychain();
-    }
+  .factory('$cordovaKeychain', ['$q', function ($q) {
 
     return {
       getForKey: function (key, serviceName) {
-        var defer = $q.defer();
+        var defer = $q.defer(),
+            kc = new Keychain();
 
         kc.getForKey(defer.resolve, defer.reject, key, serviceName);
 
@@ -19,7 +16,8 @@ angular.module('ngCordova.plugins.keychain', [])
       },
 
       setForKey: function (key, serviceName, value) {
-        var defer = $q.defer();
+        var defer = $q.defer(),
+            kc = new Keychain();
 
         kc.setForKey(defer.resolve, defer.reject, key, serviceName, value);
 
@@ -27,7 +25,8 @@ angular.module('ngCordova.plugins.keychain', [])
       },
 
       removeForKey: function (key, serviceName) {
-        var defer = $q.defer();
+        var defer = $q.defer(),
+            kc = new Keychain();
 
         kc.removeForKey(defer.resolve, defer.reject, key, serviceName);
 


### PR DESCRIPTION
Revert to using a fresh ```Keychain``` object in each call. Previous code fails when ```$cordovaKeychain``` gets initialized before ```deviceready``` event is fired.

I suggest reverting to this before there is a consensus about how to globally handle the ```deviceready``` situation accross ngCordova modules.

Change previously introduced here: https://github.com/driftyco/ng-cordova/commit/114da5522755b6efd04a2c930cc37e643307454d