### PR TITLE
Allow object to be passed to sqlite.openDatabase

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -6,16 +6,19 @@ angular.module('ngCordova.plugins.sqlite', [])
   .factory('$cordovaSQLite', ['$q', '$window', function ($q, $window) {
 
     return {
-      openDB: function (dbName, background) {
+      openDB: function (dbName, background, opt) {
+        opt = opt || {};
 
-        if (typeof background === 'undefined') {
-          background = 0;
+        if (typeof dbName === 'object'){
+          opt = dbName;
+        }
+        else {
+          opt.name = dbName;
         }
 
-        return $window.sqlitePlugin.openDatabase({
-          name: dbName,
-          bgType: background
-        });
+        opt.bgType = background || 0;
+
+        return $window.sqlitePlugin.openDatabase(opt);
       },
 
       execute: function (db, query, binding) {

--- a/test/plugins/sqlite.spec.js
+++ b/test/plugins/sqlite.spec.js
@@ -31,7 +31,7 @@ describe('Service: $cordovaSQLite', function() {
 
     spyOn(window.sqlitePlugin, 'openDatabase');
     $cordovaSQLite.openDB({
-      name: 'some-test-db'
+      name: dbName
     });
 
     expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({

--- a/test/plugins/sqlite.spec.js
+++ b/test/plugins/sqlite.spec.js
@@ -26,6 +26,20 @@ describe('Service: $cordovaSQLite', function() {
     });
   });
 
+  it('should call window\'s sqlitePlugin.open method with an options Object', function(){
+    var dbName = 'some-test-db';
+
+    spyOn(window.sqlitePlugin, 'openDatabase');
+    $cordovaSQLite.openDB({
+      name: 'some-test-db'
+    });
+
+    expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({
+      name: dbName,
+      bgType: 0
+    });
+  });
+
   it('should call window\'s sqlitePlugin.open method with background', function() {
 
     var dbName = 'someDbName';


### PR DESCRIPTION
This is to support the `location` option that the sqlite plugin supports.

See https://github.com/brodysoft/Cordova-SQLitePlugin#opening-a-database