### PR TITLE
notify instead of resolve

### DIFF
--- a/src/mocks/geolocation.js
+++ b/src/mocks/geolocation.js
@@ -147,7 +147,7 @@ ngCordovaMocks.factory('$cordovaGeolocation', ['$interval', '$q', function($inte
 											function(position) {
 												self.currentPosition = position;
 												self.locations.push(position);
-												defer.resolve(position);
+												defer.notify(position);
 											},
 											function(error) {
 												defer.reject(error);


### PR DESCRIPTION
This is an untested fix, but it seems like a bug.

The mock tests do not cover the cases where `useHostAbilities` is true, so this bug is never hit:
https://github.com/driftyco/ng-cordova/blob/master/test/mocks/geolocation.spec.js#L23

The resolve is inconsistent with the real implementation.

The geolocation plugin itself never resolves when watchPosition is used, it only has the notify callback:
See: https://github.com/driftyco/ng-cordova/blob/master/src/plugins/geolocation.js#L25

Proving the bug would require a setup which also tests the mocks inside a browser providing the capabilities.