### PR TITLE
BatteryStatus example not working. Fixed by adding correct parameter

### DIFF
--- a/demo/www/app/batteryStatus/batteryStatus.ctrl.js
+++ b/demo/www/app/batteryStatus/batteryStatus.ctrl.js
@@ -7,12 +7,12 @@ angular.module('demo.batteryStatus.ctrl', [])
     document.addEventListener("deviceready", function () {
       $scope.watch = function () {
         console.log("watching battery");
-        $cordovaBatteryStatus.$on('batterystatus', function (result) {
+        $cordovaBatteryStatus.$on('batterystatus', function (result, info) {
           $timeout(function () {
-            $scope.batteryLevel = result.level;       // (0 - 100)
-            $scope.isPluggedIn = result.isPlugged;   // bool
+            $scope.batteryLevel = info.level;       // (0 - 100)
+            $scope.isPluggedIn = info.isPlugged;   // bool
           });
-          alert("result" + result);
+          alert("Info " + info.level + " " + info.isPlugged);
         });
       };
     }, false);


### PR DESCRIPTION
This example was not working.
Listener $cordovaBatteryStatus.$on('batterystatus', function (result) is receiving incorrect number of parameter to make example work. result is only the event that was fired. info is the correct parameter that contains the level and isPlugged attributes. 
Fixed example by adding the info parameter: $cordovaBatteryStatus.$on('batterystatus', function (result, info) {
Tested on a real device (iPhone and Android)