### PR TITLE
added isInstalled method to instagram plugin

### DIFF
--- a/src/plugins/instagram.js
+++ b/src/plugins/instagram.js
@@ -23,6 +23,24 @@ angular.module('ngCordova.plugins.instagram', [])
         }
       });
       return q.promise;
+    },
+    isInstalled: function () {
+      var q = $q.defer();
+
+      if (!window.Instagram) {
+        console.error('Tried to call Instagram.isInstalled but the Instagram plugin isn\'t installed!');
+        q.resolve(null);
+        return q.promise;
+      }
+
+      Instagram.isInstalled(function (err, installed) {
+        if (err) {
+          q.reject(err);
+        } else {
+          q.resolve(installed || true);
+        }
+      });
+      return q.promise;
     }
   };
 }]);


### PR DESCRIPTION
isInstalled is quite important on Android as it returns the version of the Instagram app installed on the device, thus allowing developers to use correctly the share method that is already included in ngCordova.