### PR TITLE
Added ability to track disconnection of device

### DIFF
--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -8,9 +8,15 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
     return {
       connect: function (address) {
         var q = $q.defer();
+        var disconnectionPromise = $q.defer();
+        var isConnected = false;
         $window.bluetoothSerial.connect(address, function () {
-          q.resolve();
+          isConnected = true;
+          q.resolve(disconnectionPromise);
         }, function (error) {
+          if(isConnected === false) {
+            disconnectionPromise.reject(error);
+          }
           q.reject(error);
         });
         return q.promise;


### PR DESCRIPTION
The BluetoothSerial library utilises the error callback if the device gets disconnected once connected. Obviously with the ngCordova implementation, once the promise is resolved it cannot then be rejected. Therefore, another promise is returned if the first promise is resolved.