### PR TITLE
[Feat] Add statusbar styles to a "constant" key value obj

### DIFF
--- a/src/plugins/statusbar.js
+++ b/src/plugins/statusbar.js
@@ -9,6 +9,13 @@ angular.module('ngCordova.plugins.statusbar', [])
       overlaysWebView: function (bool) {
         return StatusBar.overlaysWebView(!!bool);
       },
+      
+      STYLES: {
+        DEFAULT: 0,
+        LIGHT_CONTENT: 1,
+        BLACK_TRANSLUCENT: 2,
+        BLACK_OPAQUE: 3
+      },
 
       style: function (style) {
         switch (style) {


### PR DESCRIPTION
I by no means think this provides a large amount of value. However, I think it's a nice way to allow developers using this service to use more semantically meaningful code.

```javascript
$cordovaStatusbar.style($cordovaStatusbar.STYLES.LIGHT_CONTENT);
//or
$cordovaStatusbar.style(1);
```

My only argument against this is that maybe "constants" don't belong peppered around the code base on individual services and instead should be in service(s) more dedicated to providing these "constants".