### PR TITLE
Returning multiple devices on scan

### DIFF
--- a/src/plugins/ble.js
+++ b/src/plugins/ble.js
@@ -3,16 +3,20 @@
 
 angular.module('ngCordova.plugins.ble', [])
 
-  .factory('$cordovaBLE', ['$q', function ($q) {
+  .factory('$cordovaBLE', ['$q', '$timeout', function ($q, $timeout) {
 
     return {
       scan: function (services, seconds) {
         var q = $q.defer();
+        var devices = [];
         ble.scan(services, seconds, function (result) {
-          q.resolve(result);
+          devices.push(result);
         }, function (error) {
           q.reject(error);
         });
+        $timeout(function() {
+        	q.resolve(devices);
+  		  }, seconds*1000);
         return q.promise;
       },
 


### PR DESCRIPTION
The scan method currently returns only a single device, although the scanning will continue for the time specified in seconds.

This patch will change the behaviour of the scan, so that devices are collected and delivered as promised as an array after the scan timeout.