### PR TITLE
Correct link to BLE plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ bower install ngCordova
 - [Badge](https://github.com/katzer/cordova-plugin-badge)
 - [Barcode Scanner](https://github.com/wildabeast/BarcodeScanner)
 - [Battery Status](https://github.com/apache/cordova-plugin-battery-status) *
-- [Bluetooth Low Energy](https://github.com/evothings/cordova-ble)
+- [Bluetooth Low Energy](https://github.com/don/cordova-plugin-ble-central)
 - [Bluetooth Serial](https://github.com/don/BluetoothSerial)
 - [Brightness](https://github.com/fiscal-cliff/phonegap-plugin-brightness)
 - [Calendar](https://github.com/EddyVerbruggen/Calendar-PhoneGap-Plugin)


### PR DESCRIPTION
Edited the link to the BLE plugin that is actually referenced in the ng-cordova source code:

    //  install   :   cordova plugin add https://github.com/don/cordova-plugin-ble-central#:/plugin
    //  link      :   https://github.com/don/cordova-plugin-ble-central