### PR TITLE
Fix camera errorhandling in example app

### DIFF
--- a/demo/www/app/camera/camera.ctrl.js
+++ b/demo/www/app/camera/camera.ctrl.js
@@ -12,7 +12,8 @@ angular.module('demo.camera.ctrl', [])
       $cordovaCamera.getPicture(options).then(function (imageData) {
         $scope.cameraimage = "data:image/jpeg;base64," + imageData;
       }, function (err) {
-        console.log('Failed because: ' + message);
+        console.log('Failed because: ');
+		console.log(err);
       });
     };
   });


### PR DESCRIPTION
Typo: message object doesn't exist.