### PR TITLE
[Feat] Add missing method for bluetoothSerial plugin

### DIFF
--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -60,6 +60,17 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       },
 
 
+      enable: function () {
+        var q = $q.defer();
+        $window.bluetoothSerial.enable(function () {
+          q.resolve();
+        }, function () {
+          q.reject();
+        });
+        return q.promise;
+      },
+
+
       isConnected: function () {
         var q = $q.defer();
         $window.bluetoothSerial.isConnected(function () {

--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -61,6 +61,12 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       },
 
 
+      setDeviceDiscoveredListener: $window.bluetoothSerial.setDeviceDiscoveredListener,
+
+
+      clearDeviceDiscoveredListener: $window.bluetoothSerial.clearDeviceDiscoveredListener,
+
+
       isEnabled: function () {
         var q = $q.defer();
         $window.bluetoothSerial.isEnabled(function () {

--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -69,7 +69,9 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
         return q.promise;
       },
 
-      clearDeviceDiscoveredListener: $window.bluetoothSerial.clearDeviceDiscoveredListener,
+      clearDeviceDiscoveredListener: function() {
+        $window.bluetoothSerial.clearDeviceDiscoveredListener();
+      },
 
 
       showBluetoothSettings: function () {

--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -67,6 +67,17 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       clearDeviceDiscoveredListener: $window.bluetoothSerial.clearDeviceDiscoveredListener,
 
 
+      showBluetoothSettings: function () {
+        var q = $q.defer();
+        $window.bluetoothSerial.showBluetoothSettings(function () {
+          q.resolve();
+        }, function (error) {
+          q.reject(error);
+        });
+        return q.promise;
+      },
+
+
       isEnabled: function () {
         var q = $q.defer();
         $window.bluetoothSerial.isEnabled(function () {

--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -49,6 +49,18 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
         return q.promise;
       },
 
+
+      discoverUnpaired: function () {
+        var q = $q.defer();
+        $window.bluetoothSerial.discoverUnpaired(function (data) {
+          q.resolve(data);
+        }, function (error) {
+          q.reject(error);
+        });
+        return q.promise;
+      },
+
+
       isEnabled: function () {
         var q = $q.defer();
         $window.bluetoothSerial.isEnabled(function () {

--- a/src/plugins/bluetoothSerial.js
+++ b/src/plugins/bluetoothSerial.js
@@ -61,8 +61,13 @@ angular.module('ngCordova.plugins.bluetoothSerial', [])
       },
 
 
-      setDeviceDiscoveredListener: $window.bluetoothSerial.setDeviceDiscoveredListener,
-
+      setDeviceDiscoveredListener: function () {
+        var q = $q.defer();
+        $window.bluetoothSerial.setDeviceDiscoveredListener(function (data) {
+          q.notify(data);
+        });
+        return q.promise;
+      },
 
       clearDeviceDiscoveredListener: $window.bluetoothSerial.clearDeviceDiscoveredListener,
 


### PR DESCRIPTION
Add support for this bluetoothSerial plugin methods:
- enable
- discoverUnpaired
- setDeviceDiscoveredListener
- clearDeviceDiscoveredListener
- showBluetoothSettings
