### PR TITLE
Enhance the camera mock with the imageData url

### DIFF
--- a/src/mocks/camera.js
+++ b/src/mocks/camera.js
@@ -5,21 +5,34 @@
  * @description
  * A service for testing camera features
  * in an app build with ngCordova.
-**/ 
+**/
 ngCordovaMocks.factory('$cordovaCamera', ['$q', function($q) {
 	var throwsError = false;
+  var imageData = '';
 
 	return {
-        /**
+
+    /**
 		 * @ngdoc property
 		 * @name throwsError
 		 * @propertyOf ngCordovaMocks.cordovaCamera
 		 *
 		 * @description
-		 * A flag that signals whether a promise should be rejected or not. 
+		 * A flag that signals whether a promise should be rejected or not.
 		 * This property should only be used in automated tests.
-		**/		
+		**/
 		throwsError: throwsError,
+
+    /**
+     * @ngdoc property
+     * @name imageData
+     * @propertyOf ngCordovaMocks.cordovaCamera
+     *
+     * @description
+     * The imagedata (e.g. an url) which will be returned from the device.
+     * This property should only be used in automated tests.
+     **/
+    imageData: imageData,
 
 		getPicture: function(options) {
 			var defer = $q.defer();
@@ -30,7 +43,7 @@ ngCordovaMocks.factory('$cordovaCamera', ['$q', function($q) {
 					options = options;	// This is just to get by JSHint.
 				}
 
-				defer.resolve();					
+        defer.resolve(this.imageData);
 			}
 			return defer.promise;
 		}

--- a/test/mocks/camera.spec.js
+++ b/test/mocks/camera.spec.js
@@ -27,6 +27,7 @@ describe('ngCordovaMocks', function() {
 
 		it('should throw an error while getting the picture.', function(done) {
 			$cordovaCamera.throwsError = true;
+      $cordovaCamera.imageData = '';
 			$cordovaCamera.getPicture(cameraOptions)
 				.then(
 					function() { expect(true).toBe(false); },
@@ -37,5 +38,41 @@ describe('ngCordovaMocks', function() {
 
 			$rootScope.$digest();
 		});
-	});
+
+    it('should return the url of the picture.', function(done) {
+      var expected = 'file:///mnt/sdcard/dummy/myImage.jpeg';
+
+      $cordovaCamera.throwsError = false;
+      $cordovaCamera.imageData = expected;
+      $cordovaCamera.getPicture(cameraOptions)
+                    .then(
+                            function(imageData) {
+                              expect(imageData).toEqual(expected);
+                            },
+                            function() {
+                              expected(false).toBe(true);
+                            } )
+                    .finally(
+                            function() {
+                              done(); });
+
+      $rootScope.$digest();
+    });
+
+    it('should return an empty string as imageData.', function(done) {
+      var expected = '';
+      $cordovaCamera.throwsError = false;
+      $cordovaCamera.getPicture(cameraOptions)
+                    .then(
+                            function(imageData) {
+                              expect(imageData).toMatch('');
+                            },
+                            function() {
+                              expect(false).toBe(true);
+                            })
+                    .finally(function() { done(); });
+
+      $rootScope.$digest();
+    });
+  });
 })


### PR DESCRIPTION
The camera mock doesn't have any possibilities to test whether the image url (imageData-Parameter) will be returned successfully.

I've enhanced the camera mock and its spec.

Thanks for your feedback.