### PR TITLE
Result structure should be consistent to the implementation (coords property)

### DIFF
--- a/test/mocks/geolocation.spec.js
+++ b/test/mocks/geolocation.spec.js
@@ -18,7 +18,7 @@ describe('ngCordovaMocks', function() {
 		}));
 
 		it('should get the current position', function (done) {
-			var expected = { x:1, y:1, z:1, timestamp:Date() };
+			var expected = {coords: { longitude:1, y:1, latitude:1 }, timestamp:Date()};
 			$cordovaGeolocation.currentPosition = expected;
 			$cordovaGeolocation.useHostAbilities = false;
 

--- a/test/mocks/geolocation.spec.js
+++ b/test/mocks/geolocation.spec.js
@@ -18,7 +18,7 @@ describe('ngCordovaMocks', function() {
 		}));
 
 		it('should get the current position', function (done) {
-			var expected = {coords: { longitude:1, y:1, latitude:1 }, timestamp:Date()};
+			var expected = {coords: { longitude:1, latitude:1 }, timestamp:Date()};
 			$cordovaGeolocation.currentPosition = expected;
 			$cordovaGeolocation.useHostAbilities = false;
 


### PR DESCRIPTION
The navigator returns the gps coordinates in a object with the structure as follows:

result.coords.latitude

The current test doesn't check with this structure.

Thanks for your feedback.

Kind regards, patrick