### PR TITLE
Inject rootScope and change timeouts to evalAsync

### DIFF
--- a/src/plugins/keyboard.js
+++ b/src/plugins/keyboard.js
@@ -3,16 +3,16 @@
 
 angular.module('ngCordova.plugins.keyboard', [])
 
-  .factory('$cordovaKeyboard', [function () {
+  .factory('$cordovaKeyboard', ['$rootScope', function ($rootScope) {
 
     var keyboardShowEvent = function () {
-      $timeout(function () {
+      $rootScope.$evalAsync(function () {
         $rootScope.$broadcast('$cordovaKeyboard:show');
       });
     };
 
     var keyboardHideEvent = function () {
-      $timeout(function () {
+      $rootScope.$evalAsync(function () {
         $rootScope.$broadcast('$cordovaKeyboard:hide');
       });
     };


### PR DESCRIPTION
Fixes errors because timeout and rootScope weren't being injected.