### PR TITLE
fix(docs): official docs url for cordova dialogs plugin

### DIFF
--- a/docs/plugins/dialogs/index.md
+++ b/docs/plugins/dialogs/index.md
@@ -4,7 +4,7 @@ title: ngCordova - Document and Examples - by the Ionic Framework Team
 
 plugin-name: $cordovaDialogs
 source: https://github.com/driftyco/ng-cordova/blob/master/src/plugins/dialogs.js
-official-docs: https://github.com/apache/cordova-plugin-dialogs/blob/master/doc/index.md
+official-docs: https://github.com/apache/cordova-plugin-dialogs
 icon-apple: true
 icon-android: true
 icon-windows: true


### PR DESCRIPTION
This fixes a broken link for "Official Docs" button for Dialogs docs.