### PR TITLE
media plugin stopRecord fixed typo

### DIFF
--- a/docs/plugins/media/index.md
+++ b/docs/plugins/media/index.md
@@ -83,7 +83,7 @@ Set the volume for audio playback.
 
 Start recording an audio file.
 
-##### `startRecord()`
+##### `stopRecord()`
 
 Stop recording an audio file.
 


### PR DESCRIPTION
Typo fix for stopRecord() method explanation