### PR TITLE
fix: inject $timeout for keyboard plugin

### DIFF
--- a/src/plugins/keyboard.js
+++ b/src/plugins/keyboard.js
@@ -3,7 +3,7 @@
 
 angular.module('ngCordova.plugins.keyboard', [])
 
-  .factory('$cordovaKeyboard', ['$rootScope', function ($rootScope) {
+  .factory('$cordovaKeyboard', ['$rootScope', '$timeout', function ($rootScope, $timeout) {
 
     var keyboardShowEvent = function () {
       $rootScope.$evalAsync(function () {


### PR DESCRIPTION
Fixes #798.

$timeout was not defined in keyboard plugin causing exceptions

![timeout-issue](https://cloud.githubusercontent.com/assets/57374/7902094/e4d2eece-076f-11e5-8935-e97b578693fc.png)


Signed-off-by: Justin Noel <justin.noel@calendee.com>