### PR TITLE
fix: remove unneeded timeout for keyboard

### DIFF
--- a/src/plugins/keyboard.js
+++ b/src/plugins/keyboard.js
@@ -3,7 +3,7 @@
 
 angular.module('ngCordova.plugins.keyboard', [])
 
-  .factory('$cordovaKeyboard', ['$rootScope', '$timeout', function ($rootScope, $timeout) {
+  .factory('$cordovaKeyboard', ['$rootScope', function ($rootScope) {
 
     var keyboardShowEvent = function () {
       $rootScope.$evalAsync(function () {


### PR DESCRIPTION
As pointed out here : https://github.com/driftyco/ng-cordova/commit/5327fc04859706d353ddab7604cba298598e72bb#diff-598495490714bb341e6096b7c375ae80,  `$timeout` is no longer required.  Was submitting with old source code that still used  `$timeout`.

Signed-off-by: Justin Noel <justin.noel@calendee.com>