### PR TITLE
Catch errors in $cordovaFlashlight promise chain

### DIFF
--- a/src/plugins/flashlight.js
+++ b/src/plugins/flashlight.js
@@ -4,44 +4,36 @@
 angular.module('ngCordova.plugins.flashlight', [])
 
   .factory('$cordovaFlashlight', ['$q', '$window', function ($q, $window) {
+    
+    /**
+     * Wraps a call to the plugin in a promise, and handles
+     * if the plugin is missing by rejecting the promise chain.
+     */
+    function willCallFlashlightPlugin(action) {
+      var q = $q.defer();
+      try {
+        $window.plugins.flashlight[action](q.resolve, q.reject);
+      } catch (e) {
+        q.reject(e);
+      }
+      return q.promise;
+    }
 
     return {
       available: function () {
-        var q = $q.defer();
-        $window.plugins.flashlight.available(function (isAvailable) {
-          q.resolve(isAvailable);
-        });
-        return q.promise;
+        return willCallFlashlightPlugin("available");
       },
 
       switchOn: function () {
-        var q = $q.defer();
-        $window.plugins.flashlight.switchOn(function (response) {
-          q.resolve(response);
-        }, function (error) {
-          q.reject(error);
-        });
-        return q.promise;
+        return willCallFlashlightPlugin("switchOn");
       },
 
       switchOff: function () {
-        var q = $q.defer();
-        $window.plugins.flashlight.switchOff(function (response) {
-          q.resolve(response);
-        }, function (error) {
-          q.reject(error);
-        });
-        return q.promise;
+        return willCallFlashlightPlugin("switchOff");
       },
 
       toggle: function () {
-        var q = $q.defer();
-        $window.plugins.flashlight.toggle(function (response) {
-          q.resolve(response);
-        }, function (error) {
-          q.reject(error);
-        });
-        return q.promise;
+        return willCallFlashlightPlugin("toggle");
       }
     };
   }]);

--- a/test/plugins/flashlight.spec.js
+++ b/test/plugins/flashlight.spec.js
@@ -35,7 +35,16 @@ describe('Service: $cordovaFlashlight', function() {
     $cordovaFlashlight.available();
     $rootScope.$digest();
 
-    expect(window.plugins.flashlight.available).toHaveBeenCalledWith(jasmine.any(Function));
+    expect(window.plugins.flashlight.available).toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
+  });
+
+  it('should gracefully handle if the plugin is not present', function() {
+      delete window.plugins.flashlight;
+
+      $cordovaFlashlight.available();
+      $rootScope.$digest();
+
+      // not exepecting an error to the be thrown
   });
 
   for (var i = 0; i < functionNames.length; i++) {


### PR DESCRIPTION
Simplify boilerplate in $cordovaFlashlight and avoid missing flashlight plugin causing an unhandled exception (eg: while testing in a browser) by capturing the exception in the promise chain.