### PR TITLE
Make additional OpenDB method

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -17,6 +17,11 @@ angular.module('ngCordova.plugins.sqlite', [])
           bgType: background
         });
       },
+      
+      advOpenDB: function (options) {
+
+        return $window.sqlitePlugin.openDatabase(options);
+      },
 
       execute: function (db, query, binding) {
         var q = $q.defer();


### PR DESCRIPTION
Without this additional method to open databases and pass options such as androidDatabaseImplementation to the cordova-sqlite-storage plugin, $cordovaSQLite is useless in environments with sqlite4java disabled