### PR TITLE
Add Google+ module back and update plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ $ bower install ngCordova
 - [Globalization](https://github.com/apache/cordova-plugin-globalization) *
 - [Google Ads](https://github.com/floatinghotpot/cordova-admob-pro)
 - [Google Analytics](https://github.com/danwilson/google-analytics-plugin)
+- [Google Plus](https://github.com/EddyVerbruggen/cordova-plugin-googleplus)
 - [HealthKit for iOS](https://github.com/Telerik-Verified-Plugins/HealthKit)
 - [Httpd (Web Server)](https://github.com/floatinghotpot/cordova-httpd)
 - [Apple iAd](https://github.com/floatinghotpot/cordova-iad-pro)

--- a/src/plugins/googlePlus.js
+++ b/src/plugins/googlePlus.js
@@ -49,11 +49,15 @@ angular.module('ngCordova.plugins.googlePlus', [])
           q.resolve(response);
         });
       },
-      
+
       isAvailable: function () {
         var q = $q.defer();
-        $window.plugins.googleplus.isAvailable(function (response) {
-          q.resolve(response);
+        $window.plugins.googleplus.isAvailable(function (available) {
+          if (available) {
+            q.resolve(available);
+          } else {
+            q.reject(available);
+          }
         });
         
         return q.promise;

--- a/src/plugins/googlePlus.js
+++ b/src/plugins/googlePlus.js
@@ -1,7 +1,7 @@
 // install  :     cordova plugin add https://github.com/EddyVerbruggen/cordova-plugin-googleplus.git
 // link     :     https://github.com/EddyVerbruggen/cordova-plugin-googleplus
 
-angular.module('ngCordova.plugins.googleplus', [])
+angular.module('ngCordova.plugins.googlePlus', [])
 
   .factory('$cordovaGooglePlus', ['$q', '$window', function ($q, $window) {
 
@@ -48,6 +48,15 @@ angular.module('ngCordova.plugins.googleplus', [])
         $window.plugins.googleplus.disconnect(function (response) {
           q.resolve(response);
         });
+      },
+      
+      isAvailable: function () {
+        var q = $q.defer();
+        $window.plugins.googleplus.isAvailable(function (response) {
+          q.resolve(response);
+        });
+        
+        return q.promise;
       }
     };
 

--- a/src/plugins/module.js
+++ b/src/plugins/module.js
@@ -36,6 +36,7 @@ angular.module('ngCordova.plugins', [
   'ngCordova.plugins.googleAnalytics',
   'ngCordova.plugins.googleMap',
   'ngCordova.plugins.googlePlayGame',
+  'ngCordova.plugins.googlePlus',
   'ngCordova.plugins.healthKit',
   'ngCordova.plugins.httpd',
   'ngCordova.plugins.iAd',


### PR DESCRIPTION
Google+ module was removed from the list (not sure why), added it back in.
Added `isAvailable` function call added in
https://github.com/EddyVerbruggen/cordova-plugin-googleplus/commit/18c9f39b24fbffd3c902bf8bbd05d1ffc9f6f600
Consistent naming with other plugins.
Fixes issue #699 and issue #796.