### PR TITLE
Malicious code in advert plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ bower install ngCordova
 ## Plugins `(63+)`
 
 - [Action Sheet](https://github.com/EddyVerbruggen/cordova-plugin-actionsheet)
-- [AdMob](https://github.com/floatinghotpot/cordova-plugin-admob)
+- [AdMob](https://github.com/floatinghotpot/cordova-plugin-admob) (:warning: share % Ad revenue)
 - [App Availability](https://github.com/ohh2ahh/AppAvailability)
 - [App Preferences](https://github.com/dferrell/plugins-application-preferences)
 - [App Rate](https://github.com/pushandplay/cordova-plugin-apprate)
@@ -57,18 +57,18 @@ $ bower install ngCordova
 - [Dialogs](https://github.com/apache/cordova-plugin-dialogs) *
 - [Email Composer](https://github.com/katzer/cordova-plugin-email-composer)
 - [Facebook Connect](https://github.com/Wizcorp/phonegap-facebook-plugin)
-- [Facebook AudienceNetwork Ads](https://github.com/floatinghotpot/cordova-plugin-facebookads)
+- [Facebook AudienceNetwork Ads](https://github.com/floatinghotpot/cordova-plugin-facebookads) (:warning: share % Ad revenue)
 - [File](https://github.com/apache/cordova-plugin-file) *
 - [File Transfer](https://github.com/apache/cordova-plugin-file-transfer) *
 - [Flashlight](https://github.com/EddyVerbruggen/Flashlight-PhoneGap-Plugin)
-- [Flurry Ads](https://github.com/floatinghotpot/cordova-plugin-flurry)
+- [Flurry Ads](https://github.com/floatinghotpot/cordova-plugin-flurry) (:warning: share % Ad revenue)
 - [Geolocation](https://github.com/apache/cordova-plugin-geolocation) *
 - [Globalization](https://github.com/apache/cordova-plugin-globalization) *
-- [Google Ads](https://github.com/floatinghotpot/cordova-admob-pro)
+- [Google Ads](https://github.com/floatinghotpot/cordova-admob-pro) (:warning: share % Ad revenue)
 - [Google Analytics](https://github.com/danwilson/google-analytics-plugin)
 - [HealthKit for iOS](https://github.com/Telerik-Verified-Plugins/HealthKit)
 - [Httpd (Web Server)](https://github.com/floatinghotpot/cordova-httpd)
-- [Apple iAd](https://github.com/floatinghotpot/cordova-iad-pro)
+- [Apple iAd](https://github.com/floatinghotpot/cordova-iad-pro) (:warning: share % Ad revenue)
 - [Image Picker](https://github.com/wymsee/cordova-imagePicker)
 - [InAppBrowser](https://github.com/apache/cordova-plugin-inappbrowser)*
 - [Keyboard](https://github.com/driftyco/ionic-plugins-keyboard)
@@ -76,9 +76,9 @@ $ bower install ngCordova
 - [Local Notifications](https://github.com/katzer/cordova-plugin-local-notifications/)
 - [Media Capture](https://github.com/apache/cordova-plugin-media-capture)
 - [Media](https://github.com/apache/cordova-plugin-media) *
-- [MillennialMedia Ads](https://github.com/floatinghotpot/cordova-plugin-mmedia)
-- [MobFox Ads](https://github.com/floatinghotpot/cordova-mobfox-pro)
-- [MoPub Ads](https://github.com/floatinghotpot/cordova-plugin-mopub)
+- [MillennialMedia Ads](https://github.com/floatinghotpot/cordova-plugin-mmedia) (:warning: share % Ad revenue)
+- [MobFox Ads](https://github.com/floatinghotpot/cordova-mobfox-pro) (:warning: share % Ad revenue)
+- [MoPub Ads](https://github.com/floatinghotpot/cordova-plugin-mopub) (:warning: share % Ad revenue)
 - [Native Audio](https://github.com/SidneyS/cordova-plugin-nativeaudio)
 - [Network Information](https://github.com/apache/cordova-plugin-network-information) *
 - [Oauth](https://github.com/nraboy/ng-cordova-oauth)


### PR DESCRIPTION
### TL;DR

All ad plugins created by [floatinghotpot](https://github.com/floatinghotpot) hijack a percentage of revenues.

### The problem 

As you can see [here](https://github.com/floatinghotpot/cordova-plugin-admob/blob/master/src/android/AdMob.java#L191) and [here](https://github.com/floatinghotpot/cordova-plugin-admob/blob/master/src/ios/CDVAdMob.m#L355) in `cordova-plugin-admob` there are 2% probability plugin use a publisher id "ca-app-pub-6869992474017983/9375997553".

A trivial response would be "open-source are wild world, you can fork and edit code" as mentioned in this [tweet](https://twitter.com/limingxie/status/506977077342400512).

*But there is more to find out...*

The AdMob plugin is an easy case to detect and resolve this issue.
If you check another plugin like [cordova-plugin-flurry](https://github.com/floatinghotpot/cordova-plugin-flurry) you will find the dependency [com.rjfun.cordova.extension](https://github.com/floatinghotpot/cordova-plugin-flurry/blob/master/plugin.xml#L24). This dependency "com.rjfun.cordova.extension" is used in most case. ([lmgtfy1](http://google.com/#q=site:github.com/floatinghotpot%20dependency%20com.rjfun.cordova.extension), [lmgtfy2](http://google.com/#q=site:github.com/floatinghotpot%20dependency%20com.rjfun.cordova.extension))

[cordova-extension](https://github.com/floatinghotpot/cordova-extension) contains binary files [cordova-generic-ad.jar](https://github.com/floatinghotpot/cordova-extension/blob/master/src/android/cordova-generic-ad.jar) and [libCordovaGenericAd.a](https://github.com/floatinghotpot/cordova-extension/blob/master/src/ios/libCordovaGenericAd.a)

After extracting and decompiling the JAR file with www.javadecompilers.com we obtain this JAVA class https://gist.github.com/zckrs/dcc1e4db3bef8563b8d9. 
Check [#L122](https://gist.github.com/zckrs/dcc1e4db3bef8563b8d9#file-cordova-generic-ad-java-L122) and [#L206](https://gist.github.com/zckrs/dcc1e4db3bef8563b8d9#file-cordova-generic-ad-java-L206)... :rage3:

All ad plugins created by floatinghotpot follows the same schema with a testing mode define on specific publisher ID ([là](https://github.com/floatinghotpot/cordova-admob-pro/blob/master/src/android/AdMobPlugin.java#L41), [là](https://github.com/floatinghotpot/cordova-plugin-facebookads/blob/master/src/android/FacebookAdPlugin.java#L35), [là](https://github.com/floatinghotpot/cordova-plugin-mmedia/blob/master/src/android/mMediaAdPlugin.java#L17), [là](https://github.com/floatinghotpot/cordova-plugin-mopub/blob/master/src/android/MoPubPlugin.java#L21), [là](https://github.com/floatinghotpot/cordova-smart-adserver/blob/master/src/android/SmartAdServerPlugin.java#L26), ...)

### The solution(s)

*Fast walkthrough*

In method [`pluginInitialize`](https://github.com/floatinghotpot/cordova-admob-pro/blob/master/src/android/AdMobPlugin.java#L54) add `testTraffic = false`

*Utopic walkthrough*

Raymond Xie will accept a PR for cordova-plugin-extension to remove this malicious code and transform the binary into a clear code. If the PR is accepted, can we still trust him?

*Best walkthrough*

A recognized organization (like Drifty or Apache) will host and manage these plugin in their namespace.

### Conclusion
Regarding the number of downloads and the omnipresence of these plugins in the cordova/phonegap community, I think users should be warned in the README ngCordova.