### PR TITLE
Media getDuration & currentTime & Q Events

### DIFF
--- a/demo/www/app/media/media.ctrl.js
+++ b/demo/www/app/media/media.ctrl.js
@@ -9,12 +9,52 @@ angular.module('demo.media.ctrl', [])
 
 
     $scope.playMedia = function () {
-      thisMedia.play();
+
+      thisMedia.play().then(function(){
+      // success
+      //Perform some action when playback finishes like playNext()
+      console.log("fire when playback finishes");
+
+        }, null, function(data){
+
+        if(data.status){
+          //Watch for status changes from the Media plugin, perform some action on start, stop, pause etc
+          //Media.MEDIA_NONE = 0;
+          //Media.MEDIA_STARTING = 1;
+          //Media.MEDIA_RUNNING = 2;
+          //Media.MEDIA_PAUSED = 3;
+          //Media.MEDIA_STOPPED = 4;
+          console.log(data.status);
+        };
+
+        if(data.duration){
+          //gets the duration of the current track, perform some action with the duration
+          console.log("track duration: " +data.duration);
+        };
+
+        if(data.position){
+          //Update the current playback position every second
+          console.log('track progress: ' + data.position);
+        };
+
+        });
       console.log("play media");
     };
 
     $scope.stopMedia = function () {
       thisMedia.pause();
+    };
+
+    $scope.getCurrentPosition = function () {
+      thisMedia.currentTime().then(function(position){
+        console.log("current playback position is:" + position);
+      });
+    };
+
+    $scope.getDuration = function () {
+      thisMedia.getDuration().then(function(duration){
+        console.log("media duration is:" + duration);
+      });
     };
 
   });

--- a/src/plugins/media.js
+++ b/src/plugins/media.js
@@ -3,75 +3,133 @@
 
 angular.module('ngCordova.plugins.media', [])
 
-  .factory('$cordovaMedia', ['$q', function ($q) {
+.service('NewMedia', ['$q', '$interval', function ($q, $interval) {
+  var q, q2, q3, mediaStatus = null, mediaPosition = -1, mediaTimer, mediaDuration = -1;
 
-    return {
-      newMedia: function (src) {
-        var q = $q.defer();
-        var mediaStatus = null;
-        var media;
+  function setTimer(media) {
+      if (angular.isDefined(mediaTimer)) return;
 
-        media = new Media(src,
-          function (success) {
-            q.resolve(success);
-          }, function (error) {
-            q.reject(error);
-          }, function (status) {
-            mediaStatus = status;
-          });
-
-        // getCurrentPosition NOT WORKING!
-        q.promise.getCurrentPosition = function () {
-          media.getCurrentPosition(function (success) {
-          }, function (error) {
-          });
-        };
-
-        q.promise.getDuration = function () {
-          media.getDuration();
-        };
-
-        // iOS quirks :
-        // -  myMedia.play({ numberOfLoops: 2 }) -> looping
-        // -  myMedia.play({ playAudioWhenScreenIsLocked : false })
-        q.promise.play = function (options) {
-          if (typeof options !== "object") {
-            options = {};
+      mediaTimer = $interval(function () {
+          if (mediaDuration < 0) {
+              mediaDuration = media.getDuration();
+              if (q && mediaDuration > 0) q.notify({duration: mediaDuration});
           }
-          media.play(options);
-        };
 
-        q.promise.pause = function () {
-          media.pause();
-        };
+          media.getCurrentPosition(
+            // success callback
+            function (position) {
+                if (position > -1) {
+                    mediaPosition = position;
+                }
+            },
+            // error callback
+            function (e) {
+                console.log("Error getting pos=" + e);
+            });
 
-        q.promise.stop = function () {
-          media.stop();
-        };
+          if (q) q.notify({position: mediaPosition});
 
-        q.promise.release = function () {
-          media.release();
-        };
+      }, 1000);
+  }
 
-        q.promise.seekTo = function (timing) {
-          media.seekTo(timing);
-        };
-
-        q.promise.setVolume = function (volume) {
-          media.setVolume(volume);
-        };
-
-        q.promise.startRecord = function () {
-          media.startRecord();
-        };
-
-        q.promise.stopRecord = function () {
-          media.stopRecord();
-        };
-
-        q.promise.media = media;
-
-        return q.promise;
+  function clearTimer() {
+      if (angular.isDefined(mediaTimer)) {
+          $interval.cancel(mediaTimer);
+          mediaTimer = undefined;
       }
-    };
-  }]);
+  }
+
+  function resetValues() {
+      mediaPosition = -1;
+      mediaDuration = -1;
+  }
+
+  function NewMedia(src) {
+      this.media = new Media(src,
+        function (success) {
+            clearTimer();
+            resetValues();
+            q.resolve(success);
+        }, function (error) {
+            clearTimer();
+            resetValues();
+            q.reject(error);
+        }, function (status) {
+            mediaStatus = status;
+            q.notify({status: mediaStatus});
+        });
+  }
+
+  // iOS quirks :
+  // -  myMedia.play({ numberOfLoops: 2 }) -> looping
+  // -  myMedia.play({ playAudioWhenScreenIsLocked : false })
+  NewMedia.prototype.play = function (options) {
+      q = $q.defer();
+
+      if (typeof options !== "object") {
+          options = {};
+      }
+
+      this.media.play(options);
+
+      setTimer(this.media);
+
+      return q.promise;
+  };
+
+  NewMedia.prototype.pause = function () {
+      clearTimer();
+      this.media.pause();
+  };
+
+  NewMedia.prototype.stop  = function () {
+      this.media.stop();
+  };
+
+  NewMedia.prototype.release  = function () {
+      this.media.release();
+      this.media = undefined;
+  };
+
+  NewMedia.prototype.seekTo  = function (timing) {
+      this.media.seekTo(timing);
+  };
+
+  NewMedia.prototype.setVolume = function (volume) {
+      this.media.setVolume(volume);
+  };
+
+  NewMedia.prototype.startRecord = function () {
+      this.media.startRecord();
+  };
+
+  NewMedia.prototype.stopRecord  = function () {
+      this.media.stopRecord();
+  };
+
+  NewMedia.prototype.currentTime = function () {
+      q2 = $q.defer();
+      this.media.getCurrentPosition(function(position){
+      q2.resolve(position);
+      });
+      return q2.promise;
+  };
+
+  NewMedia.prototype.getDuration = function () {
+    q3 = $q.defer();
+    this.media.getDuration(function(duration){
+    q3.resolve(duration);
+    });
+    return q3.promise;
+  }
+
+  return NewMedia;
+
+}])
+.factory('$cordovaMedia2', ['NewMedia', function (NewMedia) {
+  return {
+      newMedia: function (src) {
+          return new NewMedia(src);
+      }
+  };
+}]);


### PR DESCRIPTION
Should address: #821

started with the current media implementation, incorporated changes from https://github.com/arielfaur/cordovaMedia2, added further functions: getDuration() and currentTime() to provide direct methods for one time calls to these.

working promisified:
getDuration() - returns duration of current media
currentTime() - returns the current playback position (same as HTML5
audio element currentTime attribute for consistency)

Also adds some events on status changes and an interval based
continuously updating currentTime if you prefer to use that.

I have updated the demo media.ctrl.js with usage examples, these could
be incorporated into the official docs

official docs could also be updated to show that duration and
currentTime are working, removing the long standing comment that
duration and getCurrentPosition are broken.