### PR TITLE
SQLite: Pass options object to openDB

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -6,16 +6,15 @@ angular.module('ngCordova.plugins.sqlite', [])
   .factory('$cordovaSQLite', ['$q', '$window', function ($q, $window) {
 
     return {
-      openDB: function (dbName, background) {
-
-        if (typeof background === 'undefined') {
-          background = 0;
+      openDB: function (options, background) {
+        if (typeof options !== 'object') {
+          options = {name: options};
+        }
+        if (typeof background !== 'undefined') {
+          options.bgType = background;
         }
 
-        return $window.sqlitePlugin.openDatabase({
-          name: dbName,
-          bgType: background
-        });
+        return $window.sqlitePlugin.openDatabase(options);
       },
 
       execute: function (db, query, binding) {

--- a/test/plugins/sqlite.spec.js
+++ b/test/plugins/sqlite.spec.js
@@ -21,8 +21,7 @@ describe('Service: $cordovaSQLite', function() {
     $cordovaSQLite.openDB(dbName);
 
     expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({
-      name: dbName,
-      bgType: 0
+      name: dbName
     });
   });
 
@@ -36,6 +35,18 @@ describe('Service: $cordovaSQLite', function() {
     expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({
       name: dbName,
       bgType: bgType
+    });
+  });
+
+  it('should call window\'s sqlitePlugin.open method with options', function() {
+
+    var dbName = 'someDbName';
+    spyOn(window.sqlitePlugin, 'openDatabase');
+    $cordovaSQLite.openDB({name: dbName, createFromLocation: 1});
+
+    expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({
+      name: dbName,
+      createFromLocation: 1
     });
   });
 


### PR DESCRIPTION
This PR adds the possibility to pass an options object to `openDB`. The object is directly passed to `sqlitePlugin.openDatabase`.

In contrast to #653 and #851 this does not add an additional method, but changes the current `openDB()` method in a backwards compatible way.

A test is also included