### PR TITLE
Contact plugin bug: Find with empty options

### DIFF
--- a/src/plugins/contacts.js
+++ b/src/plugins/contacts.js
@@ -39,13 +39,20 @@ angular.module('ngCordova.plugins.contacts', [])
         var q = $q.defer();
         var fields = options.fields || ['id', 'displayName'];
         delete options.fields;
-
-        navigator.contacts.find(fields, function (results) {
-          q.resolve(results);
-        }, function (err) {
-          q.reject(err);
-        }, options);
-
+        if (Object.keys(options).length === 0) {
+          navigator.contacts.find(fields, function (results) {
+            q.resolve(results);
+          },function (err) {
+            q.reject(err)
+          });
+        }
+        else {
+          navigator.contacts.find(fields, function (results) {
+            q.resolve(results);
+          }, function (err) {
+            q.reject(err);
+          }, options);
+        }
         return q.promise;
       },
 


### PR DESCRIPTION
The current implementation of the ngCordova Contacts plugin doesn't handle an empty find object; it deletes the object's property ('fields'); but does not actually meet the criteria the plugin needs in order to return all contacts (it wants a null or undefined brought in); causing a bug when an options object is passed in.

This pull request resolves that bug.