### PR TITLE
Removing `npm install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 before_install:
 - npm install -g gulp bower
 - bower install
-- npm install
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
This command is running twice on CI. It's running on `before_install` and on `install` so I removed to just run once.