### PR TITLE
Ignore CODE_OF_CONDUCT.md when building a release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "src",
     "config",
     "demo",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md"
   ],
   "dependencies": {
     "angular": ">= 1.2.23"


### PR DESCRIPTION
Currently the file is shipped with the release.