### PR TITLE
Optimized gitignore - ignore only project-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
-.*.sw*
 node_modules/
-.idea/*
+bower_components/
+npm-debug.log
+_site
 demo/platforms/*
 demo/plugins/*
-_site
-bower_components
 coverage
-Gemfile.lock
-.DS_Store*
-npm-debug.log
-.project


### PR DESCRIPTION
Optimized gitignore - ignore only project-specific files and use global .gitignore for other files (like environment specific & IDEs)

More information:
https://help.github.com/articles/ignoring-files/

Related to:
https://github.com/driftyco/ng-cordova/pull/911
