### PR TITLE
Fix getDuration on media plugin

### DIFF
--- a/demo/www/app/media/media.ctrl.js
+++ b/demo/www/app/media/media.ctrl.js
@@ -52,9 +52,7 @@ angular.module('demo.media.ctrl', [])
     };
 
     $scope.getDuration = function () {
-      thisMedia.getDuration().then(function(duration){
-        console.log("media duration is:" + duration);
-      });
+      return thisMedia.getDuration();
     };
 
   });

--- a/src/plugins/media.js
+++ b/src/plugins/media.js
@@ -123,11 +123,7 @@ angular.module('ngCordova.plugins.media', [])
   };
 
   NewMedia.prototype.getDuration = function () {
-    q3 = $q.defer();
-    this.media.getDuration(function (duration){
-    q3.resolve(duration);
-    });
-    return q3.promise;
+      return this.media.getDuration();
   };
 
   return NewMedia;

--- a/src/plugins/media.js
+++ b/src/plugins/media.js
@@ -5,7 +5,7 @@
 angular.module('ngCordova.plugins.media', [])
 
 .service('NewMedia', ['$q', '$interval', function ($q, $interval) {
-  var q, q2, q3, mediaStatus = null, mediaPosition = -1, mediaTimer, mediaDuration = -1;
+  var q, q2, mediaStatus = null, mediaPosition = -1, mediaTimer, mediaDuration = -1;
 
   function setTimer(media) {
       if (angular.isDefined(mediaTimer)) {


### PR DESCRIPTION
The reason for this pull-request is media.getDuration [is synchronous](http://cordova.apache.org/docs/en/3.1.0/cordova_media_media.md.html#media.getDuration), while it is implemented as async currently.