### PR TITLE
Prevent Instagram.isInstalled from always returning `true`

### DIFF
--- a/src/plugins/instagram.js
+++ b/src/plugins/instagram.js
@@ -38,7 +38,7 @@ angular.module('ngCordova.plugins.instagram', [])
         if (err) {
           q.reject(err);
         } else {
-          q.resolve(installed || true);
+          q.resolve(installed);
         }
       });
       return q.promise;


### PR DESCRIPTION
Currently, if Instagram is not installed the promise resolves with `false || true`, which is `true`.

This PR removes the `|| true` to return the correct install status of Instagram.