### PR TITLE
Changed barcode scanner git and doc link to new repo address

### DIFF
--- a/src/plugins/barcodeScanner.js
+++ b/src/plugins/barcodeScanner.js
@@ -1,5 +1,5 @@
-// install  :    cordova plugin add https://github.com/wildabeast/BarcodeScanner.git
-// link     :    https://github.com/wildabeast/BarcodeScanner
+// install  :    cordova plugin add https://github.com/phonegap/phonegap-plugin-barcodescanner.git
+// link     :    https://github.com/phonegap/phonegap-plugin-barcodescanner
 
 angular.module('ngCordova.plugins.barcodeScanner', [])
 


### PR DESCRIPTION
From the old repo:

> Note: This repository is no longer maintained. The official repository is now at phonegap/phonegap-plugin-barcodescanner.

(Third try... hope this works.)