### PR TITLE
fixed `cordova plugin add org.apache.cordova.geolocation` to `cordova plugin add cordova-plugin-geolocation`

### DIFF
--- a/docs/plugins/geolocation/index.md
+++ b/docs/plugins/geolocation/index.md
@@ -15,7 +15,7 @@ Grab the current location of the user, or grab continuous location changes:
 
 
 ```
-cordova plugin add org.apache.cordova.geolocation
+cordova plugin add cordova-plugin-geolocation
 ```
 
 #### Methods


### PR DESCRIPTION
> cordova plugin add org.apache.cordova.geolocation
> Fetching plugin "org.apache.cordova.geolocation" via npm
> WARNING: org.apache.cordova.geolocation has been renamed to cordova-plugin-geolocation. You may not be getting the latest version! 
> We suggest you `cordova plugin rm org.apache.cordova.geolocation` and `cordova plugin add cordova-plugin-geolocation`.