### PR TITLE
Add wrapper for Toast.hide()

### DIFF
--- a/src/mocks/toast.js
+++ b/src/mocks/toast.js
@@ -85,6 +85,15 @@ ngCordovaMocks.factory('$cordovaToast', ['$q', function ($q) {
         defer.resolve();
       }
       return defer.promise;
+    },
+    hide: function () {
+      var defer = $q.defer();
+      if (this.throwsError) {
+        defer.reject('There was an error hiding the toast.');
+      } else {
+        defer.resolve();
+      }
+      return defer.promise;
     }
   };
 }]);

--- a/src/plugins/toast.js
+++ b/src/plugins/toast.js
@@ -66,7 +66,6 @@ angular.module('ngCordova.plugins.toast', [])
         return q.promise;
       },
 
-
       show: function (message, duration, position) {
         var q = $q.defer();
         $window.plugins.toast.show(message, duration, position, function (response) {
@@ -74,6 +73,17 @@ angular.module('ngCordova.plugins.toast', [])
         }, function (error) {
           q.reject(error);
         });
+        return q.promise;
+      },
+
+      hide: function () {
+        var q = $q.defer();
+        try {
+          $window.plugins.toast.hide();
+          q.resolve();
+        } catch (error) {
+          q.reject(error && error.message);
+        }
         return q.promise;
       }
     };

--- a/test/mocks/toast.spec.js
+++ b/test/mocks/toast.spec.js
@@ -8,6 +8,7 @@ describe('ngCordovaMocks', function () {
     var $cordovaToast = null;
     var message = 'A message.';
     var functionNames = [
+      'hide',
       'showShortTop',
       'showShortCenter',
       'showShortBottom',

--- a/test/plugins/toast.spec.js
+++ b/test/plugins/toast.spec.js
@@ -19,7 +19,8 @@ describe('Service: $cordovaToast', function() {
 
     window.plugins = {
       toast: {
-        show: angular.noop
+        show: angular.noop,
+        hide: angular.noop
       }
     };
 
@@ -99,7 +100,7 @@ describe('Service: $cordovaToast', function() {
     );
   });
 
-  it('should call window\'s plugins.toast.show errorCallback when recjected', function() {
+  it('should call window\'s plugins.toast.show errorCallback when rejected', function() {
     var errorResult;
 
     spyOn(window.plugins.toast, 'show')
@@ -111,6 +112,23 @@ describe('Service: $cordovaToast', function() {
       .then(angular.noop, function (response) {
         errorResult = response;
       });
+
+    $rootScope.$digest();
+
+    expect(errorResult).toBe('error response');
+  });
+
+  it('should proxy plugins.toast.hide but never fail.', function () {
+    var errorResult;
+
+    spyOn(window.plugins.toast, 'hide')
+      .andCallFake(function () {
+        throw new Error('error response');
+      });
+
+    $cordovaToast.hide().then(angular.noop, function (response) {
+      errorResult = response;
+    });
 
     $rootScope.$digest();
 


### PR DESCRIPTION
PhoneGap [Toast plugin 2.2.0](https://github.com/EddyVerbruggen/Toast-PhoneGap-Plugin/commit/4593549f4184ba5fe67641e20b4bac1552edd559) adds a `.hide()` method. Its ngCordova wrapper and mock have been updated to proxy the same method.

`.hide()` errors are handled as promise rejections.