### PR TITLE
Updated SocialSharing - available returns promise

### DIFF
--- a/src/plugins/socialSharing.js
+++ b/src/plugins/socialSharing.js
@@ -139,6 +139,7 @@ angular.module('ngCordova.plugins.socialSharing', [])
             q.reject();
           }
         });
+        return q.promise;
       }
     };
   }]);


### PR DESCRIPTION
The method available was not returning a promise. Now it returns a promise