### PR TITLE
Updated SocialSharing - available did not return promise

### DIFF
--- a/src/plugins/socialSharing.js
+++ b/src/plugins/socialSharing.js
@@ -139,6 +139,8 @@ angular.module('ngCordova.plugins.socialSharing', [])
             q.reject();
           }
         });
+        
+        return q.promise;
       }
     };
   }]);


### PR DESCRIPTION
The "Available" method did not return the promise. So promise call ran into undefined errors.