### PR TITLE
Set the pushplugin to use the official plugin

### DIFF
--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -1,6 +1,7 @@
 // install   :      cordova plugin add phonegap-plugin-push
 // link      :      https://github.com/phonegap/phonegap-plugin-push
-
+// The Official Plugin creates a global Object PushNotification
+/*globals PushNotification*/
 angular.module('ngCordova.plugins.push', [])
 
   .factory('$cordovaPush', ['$q', '$window', '$rootScope', '$timeout', function ($q, $window, $rootScope, $timeout) {
@@ -40,7 +41,7 @@ angular.module('ngCordova.plugins.push', [])
       unregister: function (options) {
         var q = $q.defer();
           if(push === null){
-            q.reject("Push not Initialized");
+            q.reject('Push not Initialized');
           } else {
             push.unregister(function (result) {
               push = null;
@@ -56,7 +57,7 @@ angular.module('ngCordova.plugins.push', [])
       setBadgeNumber: function (number) {
         var q = $q.defer();
           if(push === null){
-            q.reject("Push not Initialized");
+            q.reject('Push not Initialized');
           } else {
             push.setApplicationIconBadgeNumber(function (result) {
               q.resolve(result);

--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -1,11 +1,12 @@
-// install   :      cordova plugin add https://github.com/phonegap-build/PushPlugin.git
-// link      :      https://github.com/phonegap-build/PushPlugin
+// install   :      cordova plugin add phonegap-plugin-push
+// link      :      https://github.com/phonegap/phonegap-plugin-push
 
 angular.module('ngCordova.plugins.push', [])
 
   .factory('$cordovaPush', ['$q', '$window', '$rootScope', '$timeout', function ($q, $window, $rootScope, $timeout) {
-
+    var push;  
     return {
+        
       onNotification: function (notification) {
         $timeout(function () {
           $rootScope.$broadcast('$cordovaPush:notificationReceived', notification);
@@ -13,8 +14,10 @@ angular.module('ngCordova.plugins.push', [])
       },
 
       register: function (config) {
+          
         var q = $q.defer();
         var injector;
+        push = PushNotification.init(config);
         if (config !== undefined && config.ecb === undefined) {
           if (document.querySelector('[ng-app]') === null) {
             injector = 'document.body';
@@ -24,8 +27,8 @@ angular.module('ngCordova.plugins.push', [])
           }
           config.ecb = 'angular.element(' + injector + ').injector().get(\'$cordovaPush\').onNotification';
         }
-
-        $window.plugins.pushNotification.register(function (token) {
+        
+        push.on('registration', function (token) {
           q.resolve(token);
         }, function (error) {
           q.reject(error);
@@ -36,24 +39,31 @@ angular.module('ngCordova.plugins.push', [])
 
       unregister: function (options) {
         var q = $q.defer();
-        $window.plugins.pushNotification.unregister(function (result) {
-          q.resolve(result);
-        }, function (error) {
-          q.reject(error);
-        }, options);
-
+          if(push === undefined){
+            q.reject("Push not Initialized");
+          } else {
+            push.unregister(function (result) {
+              q.resolve(result);
+            }, function (error) {
+              q.reject(error);
+            }, options);
+          }
         return q.promise;
       },
 
       // iOS only
       setBadgeNumber: function (number) {
         var q = $q.defer();
-        $window.plugins.pushNotification.setApplicationIconBadgeNumber(function (result) {
-          q.resolve(result);
-        }, function (error) {
-          q.reject(error);
-        }, number);
-        return q.promise;
+          if(push === undefined){
+            q.reject("Push not Initialized");
+          } else {
+            push.setApplicationIconBadgeNumber(function (result) {
+              q.resolve(result);
+            }, function (error) {
+              q.reject(error);
+            }, number);
+            return q.promise;
+          }
       }
     };
   }]);

--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -4,7 +4,7 @@
 angular.module('ngCordova.plugins.push', [])
 
   .factory('$cordovaPush', ['$q', '$window', '$rootScope', '$timeout', function ($q, $window, $rootScope, $timeout) {
-    var push;  
+    var push = null;
     return {
         
       onNotification: function (notification) {
@@ -39,10 +39,11 @@ angular.module('ngCordova.plugins.push', [])
 
       unregister: function (options) {
         var q = $q.defer();
-          if(push === undefined){
+          if(push === null){
             q.reject("Push not Initialized");
           } else {
             push.unregister(function (result) {
+              push = null;
               q.resolve(result);
             }, function (error) {
               q.reject(error);
@@ -54,7 +55,7 @@ angular.module('ngCordova.plugins.push', [])
       // iOS only
       setBadgeNumber: function (number) {
         var q = $q.defer();
-          if(push === undefined){
+          if(push === null){
             q.reject("Push not Initialized");
           } else {
             push.setApplicationIconBadgeNumber(function (result) {


### PR DESCRIPTION
The before used Plugin was deprecated.
This commit sets up the ngCordovaPush to use the new and supported pushPlugin