### PR TITLE
fix "cordova plugin add inappbrowser" to new name for In App Browser

### DIFF
--- a/docs/plugins/inAppBrowser/index.md
+++ b/docs/plugins/inAppBrowser/index.md
@@ -13,7 +13,7 @@ icon-windows: true
 Provides a web browser view. It could be used to open images, access web pages, and open PDF files.
 
 ```
-cordova plugin add org.apache.cordova.inappbrowser
+cordova plugin add cordova-plugin-inappbrowser
 ```
 
 #### Methods


### PR DESCRIPTION
From my console:

> cordova plugin add org.apache.cordova.inappbrowser
> Fetching plugin "org.apache.cordova.inappbrowser" via npm
> WARNING: org.apache.cordova.inappbrowser has been renamed to cordova-plugin-inappbrowser. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.inappbrowser` and `cordova plugin add cordova-plugin-inappbrowser`.