### PR TITLE
Fixed warning about "cordova add" command

### DIFF
--- a/docs/plugins/dialogs/index.md
+++ b/docs/plugins/dialogs/index.md
@@ -13,7 +13,7 @@ icon-windows: true
 Trigger alert, confirm, and prompt windows, or send beeps (beep, beep!)
 
 ```
-cordova plugin add org.apache.cordova.dialogs
+cordova plugin add cordova-plugin-dialogs
 ```
 
 #### Methods


### PR DESCRIPTION
When I installed dialogs plugin I received the following message:

WARNING: org.apache.cordova.dialogs has been renamed to cordova-plugin-dialogs. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.dialogs` and `cordova plugin add cordova-plugin-dialogs`.

This commit only does what was suggested. ;)

Related to #1022 