### PR TITLE
Updated $cordovaAppVersion to support getAppName and getPackageName

### DIFF
--- a/src/plugins/appVersion.js
+++ b/src/plugins/appVersion.js
@@ -6,6 +6,24 @@ angular.module('ngCordova.plugins.appVersion', [])
   .factory('$cordovaAppVersion', ['$q', function ($q) {
 
     return {
+      getAppName: function () {
+        var q = $q.defer();
+        cordova.getAppVersion.getAppName(function (name) {
+          q.resolve(name);
+        });
+
+        return q.promise;
+      },
+
+      getPackageName: function () {
+        var q = $q.defer();
+        cordova.getAppVersion.getPackageName(function (package) {
+          q.resolve(package);
+        });
+
+        return q.promise;
+      },
+
       getVersionNumber: function () {
         var q = $q.defer();
         cordova.getAppVersion.getVersionNumber(function (version) {


### PR DESCRIPTION
These are supported in 0.1.7 cordova-plugin-app-version as of May 2015, see [Changelog](https://github.com/whiteoctober/cordova-plugin-app-version/releases)