### PR TITLE
Fix bug cannot clear keyboard show/hide watches

### DIFF
--- a/src/plugins/keyboard.js
+++ b/src/plugins/keyboard.js
@@ -46,12 +46,12 @@ angular.module('ngCordova.plugins.keyboard', [])
       },
 
       clearShowWatch: function () {
-        document.removeEventListener('native.keyboardshow', keyboardShowEvent);
+        window.removeEventListener('native.keyboardshow', keyboardShowEvent);
         $rootScope.$$listeners['$cordovaKeyboard:show'] = [];
       },
 
       clearHideWatch: function () {
-        document.removeEventListener('native.keyboardhide', keyboardHideEvent);
+        window.removeEventListener('native.keyboardhide', keyboardHideEvent);
         $rootScope.$$listeners['$cordovaKeyboard:hide'] = [];
       }
     };


### PR DESCRIPTION
Native keyboard listeners were registered with `window.addEventListener` but removed with `document.removeEventListener`, which didn't work. This commit replaces the latter with `window.removeEventListener` to implement the intended behavior.