### PR TITLE
New push plugin code simplification.

### DIFF
--- a/src/plugins/push_v5.js
+++ b/src/plugins/push_v5.js
@@ -8,39 +8,41 @@ angular.module('ngCordova.plugins.push_v5', [])
 
     var push;
     return {
-      initialize : function (options) {
+      register: function (options) {
         var q = $q.defer();
+
+        var registered = false;
+
         push = PushNotification.init(options);
-        q.resolve(push);
-        return q.promise;
-      },
-      onNotification : function () {
-        $timeout(function () {
-          push.on('notification', function (notification) {
-            $rootScope.$emit('$cordovaPushV5:notificationReceived', notification);
-          });
+
+        push.on('notification', function (notification) {
+            $timeout(function() {
+                $rootScope.$emit('$cordovaPushV5:notificationReceived', notification);
+            });
         });
-      },
-      onError : function () {
-        $timeout(function () {
-          push.on('error', function (error) { $rootScope.$emit('$cordovaPushV5:errorOccurred', error);});
+
+        push.on('error', function (error) {
+            if (!registered) {
+                registered = true;
+                q.reject(error);
+                return;
+            }
+
+            $timeout(function() {
+                $rootScope.$emit('$cordovaPushV5:errorOccurred', error);
+            });
         });
-      },
-      register : function () {
-        var q = $q.defer();
-        if (push === undefined) {
-          q.reject(new Error('init must be called before any other operation'));
-        } else {
-          push.on('registration', function (data) {
+
+        push.on('registration', function (data) {
             q.resolve(data.registrationId);
-          });
-        }
+        });
+
         return q.promise;
       },
       unregister : function () {
         var q = $q.defer();
         if (push === undefined) {
-          q.reject(new Error('init must be called before any other operation'));
+          q.reject(new Error('register must be called before any other operation'));
         } else {
           push.unregister(function (success) {
             q.resolve(success);
@@ -53,7 +55,7 @@ angular.module('ngCordova.plugins.push_v5', [])
       setBadgeNumber : function (number) {
         var q = $q.defer();
         if (push === undefined) {
-          q.reject(new Error('init must be called before any other operation'));
+          q.reject(new Error('register must be called before any other operation'));
         } else {
           push.setApplicationIconBadgeNumber(function (success) {
             q.resolve(success);


### PR DESCRIPTION
#963 
Hi gortok,
Thank you for your integration with new push plugin! 
I tested it and I was a bit confused with implementation...
Here is my PR.
I wanted to keep it simple and merged "initialize" and "register" method because in common case you will call them sequentially.
Possible use case of "initialize" without "register" - unregistration but it's not the case with current push plugin - https://github.com/phonegap/phonegap-plugin-push/issues/208.
Otherwise there is chance to miss "registrationId" as "PushNotification.init" registers on initialization:
```javascript
   setTimeout(function() {
       exec(success, fail, 'PushNotification', 'init', [options]);
   }, 10);
```
Register resolves with RegistrationId(token), rejects with registration error, subscribes to "notificationReceived" and "error" (as per current state of Push Plugin code errors triggers only during registration).

"onNotification" and "onError" methods - no need to call them, we can subscribe on "registration" to not miss "$cordovaPushV5:notificationReceived" and "$cordovaPushV5:errorOccurred".
```javascript
onNotification : function () {
// It's just subscription and can be done on register call.
    $timeout(function () {
      push.on('notification', function (notification) {
        $rootScope.$emit('$cordovaPushV5:notificationReceived', notification);
  });
});
```

Example for this PR:
```javascript
$rootScope.$on('$cordovaPushV5:notificationReceived', function (event, notification) {
    // ...
});

$rootScope.$on('$cordovaPushV5:errorOccurred', function (event, error) {
    // ...
});

$cordovaPushV5.register(options).then(function (token) {
    // ...
}, function (error) {
    // ...
});
```