### PR TITLE
fixed `cordova plugin add org.apache.cordova.file-transfer` to `cordova plugin add cordova-plugin-file-transfer`

### DIFF
--- a/docs/plugins/fileTransfer/index.md
+++ b/docs/plugins/fileTransfer/index.md
@@ -13,7 +13,7 @@ icon-windows: true
 This plugin allows you to upload and download files.
 
 ```
-cordova plugin add org.apache.cordova.file-transfer
+cordova plugin add cordova-plugin-file-transfer
 ```
 
 #### Methods

--- a/docs/plugins/fileTransfer/index.md
+++ b/docs/plugins/fileTransfer/index.md
@@ -61,7 +61,7 @@ module.controller('MyCtrl', function($scope, $timeout, $cordovaFileTransfer) {
 
     var url = "http://cdn.wall-pix.net/albums/art-space/00030109.jpg";
     var targetPath = cordova.file.documentsDirectory + "testImage.png";
-    var trustHosts = true
+    var trustHosts = true;
     var options = {};
 
     $cordovaFileTransfer.download(url, targetPath, options, trustHosts)
@@ -72,7 +72,7 @@ module.controller('MyCtrl', function($scope, $timeout, $cordovaFileTransfer) {
       }, function (progress) {
         $timeout(function () {
           $scope.downloadProgress = (progress.loaded / progress.total) * 100;
-        })
+        });
       });
 
    }, false);


### PR DESCRIPTION
> ionic plugin add org.apache.cordova.file-transfer
Fetching plugin "org.apache.cordova.file-transfer" via npm
WARNING: org.apache.cordova.file-transfer has been renamed to cordova-plugin-file-transfer. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.file-transfer` and `cordova plugin add cordova-plugin-file-transfer`.