### PR TITLE
fix - Added $cordovaSQLite.openDB callbacks for success and error

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -12,7 +12,7 @@ angular.module('ngCordova.plugins.sqlite', [])
           if (typeof background !== 'undefined') {
             options.bgType = background;
           }
-          return $window.sqlitePlugin.openDatabase(options);
+          return $window.sqlitePlugin.openDatabase(options, options.success, options.error);
         }
 
         return $window.sqlitePlugin.openDatabase({

--- a/test/plugins/sqlite.spec.js
+++ b/test/plugins/sqlite.spec.js
@@ -40,14 +40,14 @@ describe('Service: $cordovaSQLite', function() {
 
   it('should call window\'s sqlitePlugin.open method with options', function() {
 
-    var dbName = 'someDbName';
+    var dbName = 'someDbName', successCallback, errorCallback;
     spyOn(window.sqlitePlugin, 'openDatabase');
-    $cordovaSQLite.openDB({name: dbName, createFromLocation: 1});
+    $cordovaSQLite.openDB({name: dbName, createFromLocation: 1}, successCallback, errorCallback);
 
     expect(window.sqlitePlugin.openDatabase).toHaveBeenCalledWith({
       name: dbName,
       createFromLocation: 1
-    });
+    }, successCallback, errorCallback);
   });
 
   it('should call window\'s sqlitePlugin.deleteDB method', function() {


### PR DESCRIPTION
$cordovaSQLite.openDB hadnot callback parameters to pass to sqlitePlugin.openDatabase.
Now "options" has two new fields: "success" and "error" used as callbacks.