### PR TITLE
Make it so that users do not need to know about the "deviceready" event.

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1,4 +1,16 @@
 
 angular.module('ngCordova', [
-  'ngCordova.plugins'
-]);
+  'ngCordova.plugins',
+]).factory('deviceReady', function($q) {
+  return function() {
+    var defer = $q.defer();
+
+    document.addEventListener('deviceready', function() {
+      defer.resolve();
+    });
+
+    return defer.promise;
+  };
+});
+
+;

--- a/src/plugins/geolocation.js
+++ b/src/plugins/geolocation.js
@@ -3,41 +3,45 @@
 
 angular.module('ngCordova.plugins.geolocation', [])
 
-  .factory('$cordovaGeolocation', ['$q', function ($q) {
+  .factory('$cordovaGeolocation', ['$q','deviceReady', function ($q,deviceReady) {
 
     return {
       getCurrentPosition: function (options) {
-        var q = $q.defer();
+        return deviceReady().then(function () {
+          var q = $q.defer();
 
-        navigator.geolocation.getCurrentPosition(function (result) {
-          q.resolve(result);
-        }, function (err) {
-          q.reject(err);
-        }, options);
+          navigator.geolocation.getCurrentPosition(function (result) {
+            q.resolve(result);
+          }, function (err) {
+            q.reject(err);
+          }, options);
 
-        return q.promise;
+          return q.promise;
+        });
       },
 
       watchPosition: function (options) {
-        var q = $q.defer();
+        return deviceReady().then(function () {
+          var q = $q.defer();
 
-        var watchID = navigator.geolocation.watchPosition(function (result) {
-          q.notify(result);
-        }, function (err) {
-          q.reject(err);
-        }, options);
+          var watchId = navigator.geolocation.watchPosition(function (result) {
+            q.notify(result);
+          }, function (err) {
+            q.reject(err);
+          }, options);
 
-        q.promise.cancel = function () {
-          navigator.geolocation.clearWatch(watchID);
-        };
+          q.promise.cancel = function () {
+            navigator.geolocation.clearWatch(watchID);
+          };
 
-        q.promise.clearWatch = function (id) {
-          navigator.geolocation.clearWatch(id || watchID);
-        };
+          q.promise.clearWatch = function (id) {
+            navigator.geolocation.clearWatch(id || watchID);
+          };
 
-        q.promise.watchID = watchID;
+          q.promise.watchID = watchID;
 
-        return q.promise;
+          return q.promise;
+        });
       },
 
       clearWatch: function (watchID) {


### PR DESCRIPTION
I think it's unnecessary to require end users to care about the internal workings of cordova and cordova plugins - the point of this library is to insulate users from those implementation details.  I have added a deviceReady provider that allows plugins to wait for the device to be ready before operating, making it so that users just do the most simple thing.  I've modified the geolocation service provider to use this technique, mostly as an example.  Ideally, all of the plugins would be converted, but I don't want to do that before I've gotten some more feedback.  We could optimize the deviceReady provider somewhat, but the way it is here will/does work.

This is mainly a PR because I wanted to illustrate what I was talking about with actual code.  If there is a positive response to it and/or feedback, I can roll out a more by-the-books and fully-baked version.