### PR TITLE
The options and trust arguments seem reversed

### DIFF
--- a/src/mocks/fileTransfer.js
+++ b/src/mocks/fileTransfer.js
@@ -31,7 +31,7 @@ ngCordovaMocks.factory('$cordovaFileTransfer', ['$q', function ($q) {
          **/
         throwsError: throwsError,
 
-        download: function (source, filePath, trust, options) {
+        download: function (source, filePath, options, trust) {
             return mockIt.call(this, 'There was an error downloading the file.');
         },
 


### PR DESCRIPTION
I'm not sure how the mocks work but they aren't matching the web docs http://ngcordova.com/docs/plugins/fileTransfer/