### PR TITLE
Added missing methods and removed invalid promises for some methods

### DIFF
--- a/src/plugins/ble.js
+++ b/src/plugins/ble.js
@@ -27,16 +27,20 @@ angular.module('ngCordova.plugins.ble', [])
         return q.promise;
       },
 
-      connect: function (deviceID) {
-        var q = $q.defer();
-        ble.connect(deviceID, function (result) {
-          q.resolve(result);
-        }, function (error) {
-          q.reject(error);
-        });
-        return q.promise;
+      /**
+        * Note, can't use promise for this method because error callback is not only called when
+        * a connection is attempted and fails, it is also called when a successful connection
+        * is broken. Examples of later-broken connections are user turns power off of BLE device
+        * or move out of range
+        *
+        * @param deviceID
+        * @param successCallback
+        * @param errorCallback called with one parameter, the BLE peripheral object
+ 	      */
+      connect: function (deviceID, successCallback, errorCallback) {
+        ble.connect(deviceID, successCallback, errorCallback);
       },
-
+	  
       disconnect: function (deviceID) {
         var q = $q.defer();
         ble.disconnect(deviceID, function (result) {
@@ -67,6 +71,26 @@ angular.module('ngCordova.plugins.ble', [])
         return q.promise;
       },
 
+     /**
+      * Writes data to a characteristic without confirmation from the peripheral.
+      *
+      * TODO update docs/api regarding relevancy of success/error callbacks given the no-response nature of this api.
+      *
+      * @param deviceID
+      * @param serviceUUID
+      * @param characteristicUUID
+      * @param data If binary, use ArrayBuffer https://github.com/don/cordova-plugin-ble-central#typed-arrays
+      */
+      writeWithoutResponse: function (deviceID, serviceUUID, characteristicUUID, data) {
+        var q = $q.defer();
+        ble.writeWithoutResponse(deviceID, serviceUUID, characteristicUUID, data, function (result) {
+          q.resolve(result);
+        }, function (error) {
+          q.reject(error);
+        });
+        return q.promise;
+      },
+
       writeCommand: function (deviceID, serviceUUID, characteristicUUID, data) {
         var q = $q.defer();
         ble.writeCommand(deviceID, serviceUUID, characteristicUUID, data, function (result) {
@@ -77,14 +101,19 @@ angular.module('ngCordova.plugins.ble', [])
         return q.promise;
       },
 
-      startNotification: function (deviceID, serviceUUID, characteristicUUID) {
-        var q = $q.defer();
-        ble.startNotification(deviceID, serviceUUID, characteristicUUID, function (result) {
-          q.resolve(result);
-        }, function (error) {
-          q.reject(error);
-        });
-        return q.promise;
+	  /**
+       * Note, can't use promise for this method because dataCallback is not a success callback,
+       * it's a persistent, repeat event handler called whenever there's incoming data from
+       * the BLE peripheral.
+       *
+       * @param deviceID
+       * @param serviceUUID
+       * @param characteristicUUID
+       * @param dataCallback called with one parameter, the data
+       * @param errorCallback called with one parameter, the BLE peripheral object
+       */
+      startNotification: function (deviceID, serviceUUID, characteristicUUID, dataCallback, errorCallback) {
+        ble.startNotification(deviceID, serviceUUID, characteristicUUID, dataCallback, errorCallback);
       },
 
       stopNotification: function (deviceID, serviceUUID, characteristicUUID) {
@@ -103,6 +132,19 @@ angular.module('ngCordova.plugins.ble', [])
           q.resolve(result);
         }, function (error) {
           q.reject(error);
+        });
+        return q.promise;
+      },
+	  
+	  /**
+       * Prompts the user to enable Bluetooth.
+       */
+      enable: function() {
+        var q = $q.defer();
+        ble.enable(function() {
+          q.resolve();
+        }, function() {
+          q.reject();
         });
         return q.promise;
       },


### PR DESCRIPTION
See source code docs in ble.js

# Removed promises from these methods
### `connect`

Can't use promise for this method because error callback is not only called when
a connection is attempted and fails, it is also called when a successful connection
is broken. Examples of later-broken connections are user turns power off of BLE device
or move out of range

### `startNotification`

Can't use promise for this method because dataCallback is not a success callback, 
it's a persistent, repeat event handler called whenever there's incoming data from 
the BLE peripheral.

---

# Added these missing methods

### `writeWithoutResponse`
### `enable`

Thanks to [Don Coleman](https://github.com/don) for support with these changes