### PR TITLE
Adding push.finish() method - required in iOS

### DIFF
--- a/src/plugins/push_v5.js
+++ b/src/plugins/push_v5.js
@@ -62,6 +62,19 @@ angular.module('ngCordova.plugins.push_v5', [])
           }, number);
         }
         return q.promise;
+      },
+      finish: function(){
+        var q = $q.defer();
+        if (push === undefined) {
+          q.reject(new Error('init must be called before any other operation'));
+        } else {
+          push.finish(function (success) {
+            q.resolve(success);
+          }, function (error) {
+            q.reject(error);
+          });
+        }
+        return q.promise;
       }
     };
   }]);


### PR DESCRIPTION
to signal completion of background processes, push.finish() needs to be called or iOS may terminate the process thinking that it is misbehaving. Adding that.