### PR TITLE
created inappbrowser mock

### DIFF
--- a/src/mocks/inappbrowser.js
+++ b/src/mocks/inappbrowser.js
@@ -1,0 +1,35 @@
+/**
+ * @ngdoc service
+ * @name ngCordovaMocks.cordovaInAppBrowser
+ *
+ * @description
+ * A service to open links on exteral browser. This mock does nothing, but if you don't declare it
+ * the tests of your application will break.
+ **/
+ngCordovaMocks.provider('$cordovaInAppBrowser', [function() {
+
+  this.setDefaultOptions = function() {};
+
+  this.$get = ['$q', function($q) {
+
+    var dummyPromise = function() {
+      var q = $q.defer();
+
+      q.resolve(true);
+
+      return q.promise;
+    };
+
+    return {
+      open: dummyPromise,
+
+      close: angular.noop,
+
+      show: angular.noop,
+
+      executeScript: dummyPromise,
+
+      insertCSS: dummyPromise
+    };
+  }];
+}]);

--- a/test/mocks/inappbrowser.spec.js
+++ b/test/mocks/inappbrowser.spec.js
@@ -1,0 +1,43 @@
+describe('ngCordovaMocks', function() {
+	beforeEach(function() {
+		module('ngCordovaMocks');
+	});
+
+	describe('cordovaInAppBrowser', function () {
+		var $cordovaInAppBrowser;
+
+		beforeEach(inject(function (_$cordovaInAppBrowser_) {
+			$cordovaInAppBrowser = _$cordovaInAppBrowser_;
+		}));
+
+		it('should exists', function () {
+			expect($cordovaInAppBrowser).toBeDefined();
+		});
+
+		it('should have an \'open\' method', function () {
+			expect($cordovaInAppBrowser.open).toBeDefined();
+			expect(angular.isFunction($cordovaInAppBrowser.open)).toBe(true);
+		});
+
+		it('should have an \'close\' method', function () {
+			expect($cordovaInAppBrowser.close).toBeDefined();
+			expect(angular.isFunction($cordovaInAppBrowser.close)).toBe(true);
+		});
+
+		it('should have an \'show\' method', function () {
+			expect($cordovaInAppBrowser.show).toBeDefined();
+			expect(angular.isFunction($cordovaInAppBrowser.show)).toBe(true);
+		});
+
+		it('should have an \'executeScript\' method', function () {
+			expect($cordovaInAppBrowser.executeScript).toBeDefined();
+			expect(angular.isFunction($cordovaInAppBrowser.executeScript)).toBe(true);
+		});
+
+		it('should have an \'insertCSS\' method', function () {
+			expect($cordovaInAppBrowser.insertCSS).toBeDefined();
+			expect(angular.isFunction($cordovaInAppBrowser.insertCSS)).toBe(true);
+		});
+	});
+
+});


### PR DESCRIPTION
If you use cordovaInAppBrowser on your application, you cannot launch e2e tests with ngCordovaMocks. I've created an empty stub for this service in the ngCordovaMocks module, in this way we have no problem bootstrapping the application in the test enviroment. Otherwise we encounter a "service not found" problem.