### PR TITLE
fixing default task on gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ var gulp = require('gulp'),
   jscs = require('gulp-jscs'),
   git = require('gulp-git');
 
-gulp.task('default', ['git', 'build']);
+gulp.task('default', ['build']);
 
 gulp.task('lint', ['jshint', 'jscs']);
 


### PR DESCRIPTION
Since the 'git' task it's been removed, I removed it from the default gulp task