### PR TITLE
Switch mode network mock

### DIFF
--- a/src/mocks/network.js
+++ b/src/mocks/network.js
@@ -6,7 +6,7 @@
  * A service for testing networked fetures
  * in an app build with ngCordova.
  */
-ngCordovaMocks.factory('$cordovaNetwork', function () {
+ngCordovaMocks.factory('$cordovaNetwork', ['$rootScope',function ($rootScope) {
   var connectionType = 'WiFi connection';
   var isConnected = true;
 
@@ -34,6 +34,16 @@ ngCordovaMocks.factory('$cordovaNetwork', function () {
      **/
     isConnected: isConnected,
 
+    switchToOnline: function(){
+      this.isConnected = true;
+      $rootScope.$broadcast('$cordovaNetwork:online');
+    },
+
+    switchToOffline: function(){
+      this.isConnected = false;
+      $rootScope.$broadcast('$cordovaNetwork:offline');
+    },
+
     getNetwork: function () {
       return this.connectionType;
     },
@@ -46,4 +56,4 @@ ngCordovaMocks.factory('$cordovaNetwork', function () {
       return !this.isConnected;
     }
   };
-});
+}]);

--- a/test/mocks/network.spec.js
+++ b/test/mocks/network.spec.js
@@ -5,8 +5,12 @@ describe('ngCordovaMocks', function() {
 
 	describe('cordovaNetwork', function () {
 		var $cordovaNetwork = null;
+		var $rootScope = null;
+		var $cordovaNetwork = null;
 
-		beforeEach(inject(function (_$cordovaNetwork_) {
+		beforeEach(inject(function (_$cordovaNetwork_,_$rootScope_,_$cordovaNetwork_) {
+			$cordovaNetwork = _$cordovaNetwork_;
+			$rootScope = _$rootScope_;
 			$cordovaNetwork = _$cordovaNetwork_;
 		}));
 
@@ -25,6 +29,30 @@ describe('ngCordovaMocks', function() {
 		it('should check if offline', function() {
 			var isOffline = $cordovaNetwork.isOffline();
 			expect(isOffline).toBe(false);
-		})
+		});
+
+		it('should launch listeners when switching to online', function() {
+			var isOnline = false;
+
+			$rootScope.$on('$cordovaNetwork:online',function(){
+				isOnline = $cordovaNetwork.isOnline();
+			});
+
+			$cordovaNetwork.switchToOnline();
+
+			expect(isOnline).toBe(true);
+		});
+
+		it('should launch listeners when switching to online', function() {
+			var isOffline = false;
+
+			$rootScope.$on('$cordovaNetwork:offline',function(){
+				isOffline = $cordovaNetwork.isOffline();
+			});
+
+			$cordovaNetwork.switchToOffline();
+
+			expect(isOffline).toBe(true);
+		});
 	});
 })


### PR DESCRIPTION
In previous version of $cordovaNetwork mock you cannot test the switch to offline mode and viceversa. I've added two methods that will do that launching the right events through the rootscope.

