### PR TITLE
Removed 'git' task and ref from gulpfile.js as no longer used

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,10 +14,9 @@ var gulp = require('gulp'),
   changelog = require('conventional-changelog'),
   q = require('q'),
   fs = require('fs'),
-  jscs = require('gulp-jscs'),
-  git = require('gulp-git');
+  jscs = require('gulp-jscs');
 
-gulp.task('default', ['git', 'build']);
+gulp.task('default', ['build']);
 
 gulp.task('lint', ['jshint', 'jscs']);
 


### PR DESCRIPTION
Fix: As per #1141 this removes mentions of _git_, as it's no longer used