### PR TITLE
added method to src,mocks, and respective tests

### DIFF
--- a/src/mocks/toast.js
+++ b/src/mocks/toast.js
@@ -77,6 +77,15 @@ ngCordovaMocks.factory('$cordovaToast', ['$q', function ($q) {
       }
       return defer.promise;
     },
+    showWithOptions: function (options) {
+      var defer = $q.defer();
+      if (this.throwsError) {
+        defer.reject('There was an error showing the toast.');
+      } else {
+        defer.resolve();
+      }
+      return defer.promise;
+		},
     show: function (message, duration, position) {
       var defer = $q.defer();
       if (this.throwsError) {

--- a/src/plugins/toast.js
+++ b/src/plugins/toast.js
@@ -66,6 +66,16 @@ angular.module('ngCordova.plugins.toast', [])
         return q.promise;
       },
 
+      showWithOptions: function (options) {
+        var q = $q.defer();
+        $window.plugins.toast.showWithOptions(options, function (response) {
+          q.resolve(response);
+        }, function (error) {
+          q.reject(error);
+        });
+        return q.promise;
+      },
+
       show: function (message, duration, position) {
         var q = $q.defer();
         $window.plugins.toast.show(message, duration, position, function (response) {

--- a/test/mocks/toast.spec.js
+++ b/test/mocks/toast.spec.js
@@ -15,6 +15,7 @@ describe('ngCordovaMocks', function () {
       'showLongTop',
       'showLongCenter',
       'showLongBottom',
+      'showWithOptions',
       'show'
     ];
 

--- a/test/plugins/toast.spec.js
+++ b/test/plugins/toast.spec.js
@@ -8,6 +8,7 @@ describe('Service: $cordovaToast', function() {
     'showShortBottom',
     'showLongTop',
     'showLongCenter',
+    'showWithOptions',
     'showLongBottom'
   ];
 


### PR DESCRIPTION
Hi there, Any chance we could add `showWithOptions` to `$cordovaToast`?  Please let me know if I need to update any of the changes - or if there's some sort of issue with the plugin's underlying method that warrants its exclusion from ng-cordova.  Thanks!
-Brian