### PR TITLE
fix: remove duplicate text in page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: ngCordova - Simple extensions for common Cordova Plugins - by the Ionic Team
+title: ngCordova - Simple extensions for common Cordova Plugins
 ---
 
 <div class="container">


### PR DESCRIPTION
" - by the Ionic Team" already coming from _layouts/default.html

![title_issue](https://cloud.githubusercontent.com/assets/1189149/13594750/776e2334-e541-11e5-9c5e-793196f56041.png)
