### PR TITLE
Fix for ES6 - package is a reserved word.

### DIFF
--- a/demo/www/lib/ngCordova/dist/ng-cordova.js
+++ b/demo/www/lib/ngCordova/dist/ng-cordova.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */
@@ -240,8 +240,8 @@ angular.module('ngCordova.plugins.appVersion', [])
 
       getPackageName: function () {
         var q = $q.defer();
-        cordova.getAppVersion.getPackageName(function (package) {
-          q.resolve(package);
+        cordova.getAppVersion.getPackageName(function (pkg) {
+          q.resolve(pkg);
         });
 
         return q.promise;

--- a/demo/www/lib/ngCordova/dist/ng-cordova.min.js
+++ b/demo/www/lib/ngCordova/dist/ng-cordova.min.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */

--- a/dist/ng-cordova-mocks.js
+++ b/dist/ng-cordova-mocks.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */

--- a/dist/ng-cordova-mocks.min.js
+++ b/dist/ng-cordova-mocks.min.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */

--- a/dist/ng-cordova.js
+++ b/dist/ng-cordova.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */
@@ -240,8 +240,8 @@ angular.module('ngCordova.plugins.appVersion', [])
 
       getPackageName: function () {
         var q = $q.defer();
-        cordova.getAppVersion.getPackageName(function (package) {
-          q.resolve(package);
+        cordova.getAppVersion.getPackageName(function (pkg) {
+          q.resolve(pkg);
         });
 
         return q.promise;

--- a/dist/ng-cordova.min.js
+++ b/dist/ng-cordova.min.js
@@ -1,6 +1,6 @@
 /*!
  * ngCordova
- * v0.1.23-alpha
+ * v0.1.24-alpha
  * Copyright 2015 Drifty Co. http://drifty.com/
  * See LICENSE in this repository for license information
  */

--- a/src/plugins/appVersion.js
+++ b/src/plugins/appVersion.js
@@ -17,8 +17,8 @@ angular.module('ngCordova.plugins.appVersion', [])
 
       getPackageName: function () {
         var q = $q.defer();
-        cordova.getAppVersion.getPackageName(function (package) {
-          q.resolve(package);
+        cordova.getAppVersion.getPackageName(function (pkg) {
+          q.resolve(pkg);
         });
 
         return q.promise;


### PR DESCRIPTION
This is a fix for the error "package is a reserved word" when using it with Babel-preset-es2015.