### PR TITLE
Add #getBadgeNumber to $cordovaPushV5

### DIFF
--- a/src/plugins/push_v5.js
+++ b/src/plugins/push_v5.js
@@ -62,6 +62,19 @@ angular.module('ngCordova.plugins.push_v5', [])
           }, number);
         }
         return q.promise;
+      },
+      getBadgeNumber : function () {
+        var q = $q.defer();
+        if (push === undefined) {
+          q.reject(new Error('init must be called before any other operation'));
+        } else {
+          push.getApplicationIconBadgeNumber(function (badgeNumber) {
+            q.resolve(badgeNumber);
+          }, function (error) {
+            q.reject(error);
+          });
+        }
+        return q.promise;
       }
     };
   }]);


### PR DESCRIPTION
Simply adds new method #getBadgeNumber that wraps
the method #getApplicationIconBadgeNumber from the plugin into a Promise
object the plugin into a Promise object.