### PR TITLE
Fixed new open database arguments

### DIFF
--- a/src/plugins/sqlite.js
+++ b/src/plugins/sqlite.js
@@ -6,18 +6,26 @@ angular.module('ngCordova.plugins.sqlite', [])
   .factory('$cordovaSQLite', ['$q', '$window', function ($q, $window) {
 
     return {
-      openDB: function (options, background) {
+      openDB: function (options, background, location, iosLocation) {
 
         if (angular.isObject(options) && !angular.isString(options)) {
           if (typeof background !== 'undefined') {
             options.bgType = background;
+          }
+          if (typeof location !== 'undefined') {
+            options.location = location;
+          }
+          if (typeof iosLocation !== 'undefined') {
+            options.iosDatabaseLocation = iosLocation;
           }
           return $window.sqlitePlugin.openDatabase(options);
         }
 
         return $window.sqlitePlugin.openDatabase({
           name: options,
-          bgType: background
+          bgType: background,
+          location: location,
+          iosDatabaseLocation: iosLocation
         });
       },
 


### PR DESCRIPTION
According to https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database is required to add new openDB arguments.
`var db = window.sqlitePlugin.openDatabase({name: 'my.db', location: 'default', iosDatabaseLocation: 'Library'}, successcb, errorcb);`