### PR TITLE
Added missing data query methods for healthkit plugin in healthKit.js

### DIFF
--- a/src/plugins/healthKit.js
+++ b/src/plugins/healthKit.js
@@ -223,5 +223,41 @@ angular.module('ngCordova.plugins.healthKit', [])
         );
         return q.promise;
       }
+      queryCorrelationType: function (correlationQuery) {
+        var q = $q.defer();
+        $window.plugins.healthkit.queryCorrelationType(correlationQuery,
+            function (success) {
+              q.resolve(success);
+            },
+            function (err) {
+              q.resolve(err);
+            }
+        );
+        return q.promise;
+      },
+      sumQuantityType: function (sampleQuery) {
+        var q = $q.defer();
+        $window.plugins.healthkit.sumQuantityType(sampleQuery,
+            function (success) {
+              q.resolve(success);
+            },
+            function (err) {
+              q.resolve(err);
+            }
+        );
+        return q.promise;
+      },
+      querySampleTypeAggregated: function (sampleQuery) {
+        var q = $q.defer();
+        $window.plugins.healthkit.querySampleTypeAggregated(sampleQuery,
+            function (success) {
+              q.resolve(success);
+            },
+            function (err) {
+              q.resolve(err);
+            }
+        );
+        return q.promise;
+      }
     };
   }]);


### PR DESCRIPTION
Added missing data query methods for healthkit plugin (queryCorrelationType, sumQuantityType, querySampleTypeAggregated).
Opened issue is here: #939