### PR TITLE
Fixed Docs - Added link to the new Push Notification V5 plugin.

### DIFF
--- a/_layouts/docs-plugins.html
+++ b/_layouts/docs-plugins.html
@@ -127,6 +127,7 @@
 							<li><a href="/docs/plugins/printer/">Printer</a></li>
 							<li><a href="/docs/plugins/progressIndicator/">Progress Indicator</a></li>
 							<li><a href="/docs/plugins/pushNotifications/">Push Notifications</a></li>
+							<li><a href="/docs/plugins/pushNotificationsV5/">Push Notifications V5</a></li>
 							<li><a href="/docs/plugins/sms/">SMS</a></li>
 							<li><a href="/docs/plugins/socialSharing/">Social Sharing</a></li>
 							<li><a href="/docs/plugins/spinnerDialog/">Spinner Dialog</a></li>

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -276,6 +276,12 @@
     "short-title": "PushNotifications"
   },
   {
+    "link": "/docs/plugins/pushNotificationsV5/",
+    "title": "Push Notifications V5",
+    "keywords": "APN GCM",
+    "short-title": "PushNotificationsV5"
+  },
+  {
     "link": "/docs/plugins/socialSharing/",
     "title": "Social Sharing",
     "keywords": "email twitter facebook SMS",

--- a/docs/plugins/pushNotifications/index.md
+++ b/docs/plugins/pushNotifications/index.md
@@ -11,6 +11,7 @@ icon-windows: true
 ---
 
 # [DEPRECATED] 
+
 ## The `PushPlugin` is deprecated. Use the `$cordovaPushV5` which is the service for [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push).
 
 Allows your application to receive push notifications. To receive notifications in your controllers or services, listen for `$cordovaPush:notificationReceived` event.


### PR DESCRIPTION
#1279 's modification wasn't enough. (apologies) 

Added link to the new Push Notification V5 plugin.

Fixed invalid markdown on the old Push Notification page.