### PR TITLE
Add advertising id collection support (to $cordovaGoogleAnalytics)

### DIFF
--- a/src/mocks/googleAnalytics.js
+++ b/src/mocks/googleAnalytics.js
@@ -25,6 +25,7 @@ ngCordovaMocks.factory('$cordovaGoogleAnalytics', ['$q', function ($q) {
     'startTrackerWithId',
     'setUserId',
     'debugMode',
+    'setAllowIDFACollection';
     'trackView',
     'addCustomDimension',
     'trackEvent',

--- a/src/mocks/googleAnalytics.js
+++ b/src/mocks/googleAnalytics.js
@@ -25,7 +25,7 @@ ngCordovaMocks.factory('$cordovaGoogleAnalytics', ['$q', function ($q) {
     'startTrackerWithId',
     'setUserId',
     'debugMode',
-    'setAllowIDFACollection';
+    'setAllowIDFACollection',
     'trackView',
     'addCustomDimension',
     'trackEvent',

--- a/src/plugins/googleAnalytics.js
+++ b/src/plugins/googleAnalytics.js
@@ -42,6 +42,20 @@ angular.module('ngCordova.plugins.googleAnalytics', [])
         return d.promise;
       },
 
+      setAllowIDFACollection: function(enable) {
+        var d = $q.defer();
+
+        if(typeof(enable) === 'undefined') {
+          enable = true;
+        }
+
+        $window.analytics.setAllowIDFACollection(enable, function (response) {
+          d.resolve(response);
+        }, function () {
+          d.reject();
+        });
+      },
+
       trackView: function (screenName) {
         var d = $q.defer();
 


### PR DESCRIPTION
Add the avaliabilty of enable the Google Analytics Advertising ID Collection using the new function added to the plugin (in https://github.com/danwilson/google-analytics-plugin/pull/252). This allows to collect demographics and interest reports (as described in https://support.google.com/analytics/answer/2444872)

It was added to the plugin two days ago, after a lot of requests from users. I think that would be amazing have that feature available in ng-cordova asap, so I did it.

_p.d.: This is my first contribution here, so if there is something I have forgotten, please, tell me to do it!_