### PR TITLE
chore(npm): remove fs npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "conventional-changelog": "0.0.11",
-    "fs": "0.0.2",
     "gulp-git": "^1.2.4",
     "q": "^1.1.2"
   }


### PR DESCRIPTION
The module `fs` is not actually needed to require the standard library
`fs`. This module was temporarily wiped, since the whole module only consists
out of a single `console.log(...)` [1].

[1] http://status.npmjs.org/incidents/dw8cr1lwxkcr