### PR TITLE
Added PushPlugin 'hasPermission' method to cordovaPushV5

### DIFF
--- a/src/plugins/push_v5.js
+++ b/src/plugins/push_v5.js
@@ -14,6 +14,13 @@ angular.module('ngCordova.plugins.push_v5', [])
         q.resolve(push);
         return q.promise;
       },
+      hasPermission : function () {
+        var q = $q.defer();
+        PushNotification.hasPermission(function(response) {
+          q.resolve(response);
+        });
+        return q.promise;
+      },
       onNotification : function () {
         $timeout(function () {
           push.on('notification', function (notification) {

--- a/test/plugins/push_V5.spec.js
+++ b/test/plugins/push_V5.spec.js
@@ -1,0 +1,53 @@
+describe('Service: $cordovaPushV5', function() {
+
+  var $cordovaPushV5, $rootScope;
+
+  beforeEach(module('ngCordova.plugins.push_v5'));
+
+  beforeEach(inject(function (_$cordovaPushV5_, _$rootScope_) {
+    $cordovaPushV5 = _$cordovaPushV5_;
+    $rootScope = _$rootScope_;
+
+
+    window.PushNotification = {
+      init: angular.noop,
+      hasPermission: angular.noop,
+    };
+  }));
+
+  it('should call the PushNotification.init method', function() {
+
+    var result;
+    var config = { someConfig: 1 };
+
+    spyOn(window.PushNotification, 'init').and.returnValue(true);
+
+    $cordovaPushV5.initialize(config)
+      .then(function (response) {
+        result = response;
+      });
+
+    $rootScope.$digest();
+    expect(window.PushNotification.init.calls.argsFor(0)[0]).toBe(config);
+    expect(result).toBe(true);
+  });
+
+  it('should call the PushNotification.hasPermission method', function() {
+
+    var result;
+
+    spyOn(window.PushNotification, 'hasPermission')
+      .and.callFake(function (successCb) {
+        successCb({ isEnabled: true });
+      });
+
+    $cordovaPushV5.hasPermission()
+      .then(function (response) {
+        result = response;
+      });
+
+    $rootScope.$digest();
+    expect(window.PushNotification.hasPermission).toHaveBeenCalled;
+    expect(result.isEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Related to Issue #1333 

## Problem
(https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/API.md#pushnotificationhaspermissionsuccesshandler---android--ios-only)
`phonegap-plugin-push` has a method called `hasPermission` that can be used to determine whether or not a user has allowed push notifications for a specific app in iOS/Android settings.  ngCordova's implementation of this plugin does not include this method.

## Solution
Added a `hasPermission` method to cordovaPushV5.  Also, there were no specs for cordovaPushV5, so I added a spec file and wrote specs for `init` and `hasPermission`.

## Details
I wanted to open this PR and get feedback before writing the entire spec suite for $cordovaPushV5, but I'd be happy to either add that here or open another PR.  Also, $cordovaPushV5 appears to not have any mocks in place, same thing, can add here or open another PR for those as well.