### PR TITLE
Changed license field in package.json and added keywords + Readme title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 [ngCordova](http://ngcordova.com/)
+
 ==========
 
 [![Travis](https://img.shields.io/travis/driftyco/ng-cordova.svg?style=flat)](https://travis-ci.org/driftyco/ng-cordova) [![Bower](https://img.shields.io/badge/bower-ngCordova-FFCC2F.svg?style=flat)](http://bower.io/search/?q=ngCordova)

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "minimist": "^0.1.0",
     "phantomjs-prebuilt": "^2.1.4"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
+  "license": "MIT",
+  "keywords": [
+    "cordova",
+    "angularjs"
   ],
   "scripts": {
     "test": "gulp lint && gulp karma --browsers=PhantomJS --reporters=progress"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,18 @@
     "minimist": "^0.1.0",
     "phantomjs-prebuilt": "^2.1.4"
   },
-  "license": "MIT",
+
   "keywords": [
+    "ngCordova",
+    "ng-cordova",
+    "ngcordova",
+    "ng cordova",
     "cordova",
-    "angularjs"
+    "phonegap",
+    "angular",
+    "angularjs",
+    "ionic",
+    "cordova plugin"
   ],
   "scripts": {
     "test": "gulp lint && gulp karma --browsers=PhantomJS --reporters=progress"


### PR DESCRIPTION
Running npm install showed an warning that no license field exists. I changed the value to the correct structure. I also added two keywords in in package.json to make this module easier to find on npm.

Looking at the page at npmjs.org showed some strange formatting. I tried to avoid this with adding a linebreak in the README file.

![bildschirmfoto vom 2016-08-25 18-04-46](https://cloud.githubusercontent.com/assets/3585860/17976613/7b5772ba-6aee-11e6-9220-bcbaf435fe52.png)
