### PR TITLE
the 'OR' operator ignores all zero values 

### DIFF
--- a/src/plugins/appRate.js
+++ b/src/plugins/appRate.js
@@ -30,7 +30,7 @@ angular.module('ngCordova.plugins.appRate', [])
       AppRate.preferences.displayAppName = defaults.appName || '';
       AppRate.preferences.promptAgainForEachNewVersion = defaults.promptForNewVersion || true;
       AppRate.preferences.openStoreInApp = defaults.openStoreInApp || false;
-      AppRate.preferences.usesUntilPrompt = defaults.usesUntilPrompt || 3;
+      AppRate.preferences.usesUntilPrompt = (typeof defaults.usesUntilPrompt === 'undefined'|| defaults.usesUntilPrompt===null)?3:defaults.usesUntilPrompt;
       AppRate.preferences.useCustomRateDialog = defaults.useCustomRateDialog || false;
       AppRate.preferences.storeAppURL.ios = defaults.iosURL || null;
       AppRate.preferences.storeAppURL.android = defaults.androidURL || null;


### PR DESCRIPTION
when checking if a preference value is defined for `usesUntilPrompt`. The current logic disregards the configured `0` value passed into `$cordovaAppRateProvider.setPreferences` and assigns the default value instead, `3`.