### PR TITLE
watchPosition should call notify, not resolve

### DIFF
--- a/src/mocks/geolocation.js
+++ b/src/mocks/geolocation.js
@@ -148,7 +148,7 @@ ngCordovaMocks.factory('$cordovaGeolocation', ['$interval', '$q', function ($int
                       function (position) {
                         self.currentPosition = position;
                         self.locations.push(position);
-                        defer.resolve(position);
+                        defer.notify(position);
                       },
                       function (error) {
                         defer.reject(error);


### PR DESCRIPTION
watchPosition returns a promise which issues updates to the notify function