### PR TITLE
Fix fingerprint description link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ bower install ngCordova
 - [Facebook AudienceNetwork Ads](https://github.com/floatinghotpot/cordova-plugin-facebookads) (:warning: share % Ad revenue)
 - [File](https://github.com/apache/cordova-plugin-file) *
 - [File Transfer](https://github.com/apache/cordova-plugin-file-transfer) *
-- [Fingerprint](https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio) *
+- [Fingerprint](https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio)
 - [Flashlight](https://github.com/EddyVerbruggen/Flashlight-PhoneGap-Plugin)
 - [Flurry Ads](https://github.com/floatinghotpot/cordova-plugin-flurry) (:warning: share % Ad revenue)
 - [Geolocation](https://github.com/apache/cordova-plugin-geolocation) *


### PR DESCRIPTION
I just found the "*" symbol next next to the fingerprint link in README. This plugin should not be marked as an official plugin.

@gortok btw. Are there any plans for a new release of ngCordova?