### PR TITLE
Update googleAnalytics.js

### DIFF
--- a/src/plugins/googleAnalytics.js
+++ b/src/plugins/googleAnalytics.js
@@ -45,7 +45,7 @@ angular.module('ngCordova.plugins.googleAnalytics', [])
       trackView: function (screenName) {
         var d = $q.defer();
 
-        $window.analytics.trackView(screenName, function (response) {
+        $window.analytics.trackView(screenName, '', false, function (response) {
           d.resolve(response);
         }, function (error) {
           d.reject(error);


### PR DESCRIPTION
google-analytics-plugin for trackView function expect 3 arguments before the success + err callback (screen, campaingUrl, newSession). Added default param of empty string and boolean