### PR TITLE
Google Analytics: API Update

### DIFF
--- a/src/plugins/googleAnalytics.js
+++ b/src/plugins/googleAnalytics.js
@@ -6,10 +6,10 @@ angular.module('ngCordova.plugins.googleAnalytics', [])
   .factory('$cordovaGoogleAnalytics', ['$q', '$window', function ($q, $window) {
 
     return {
-      startTrackerWithId: function (id) {
+      startTrackerWithId: function (id, dispatchPeriod) {
         var d = $q.defer();
 
-        $window.ga.startTrackerWithId(id, function (response) {
+        $window.ga.startTrackerWithId(id, dispatchPeriod, function (response) {
           d.resolve(response);
         }, function (error) {
           d.reject(error);
@@ -54,10 +54,10 @@ angular.module('ngCordova.plugins.googleAnalytics', [])
         return d.promise;
       },
 
-      trackView: function (screenName) {
+      trackView: function (screenName, campaingUrl, newSession) {
         var d = $q.defer();
 
-        $window.ga.trackView(screenName, function (response) {
+        $window.ga.trackView(screenName, campaingUrl, newSession, function (response) {
           d.resolve(response);
         }, function (error) {
           d.reject(error);
@@ -83,10 +83,10 @@ angular.module('ngCordova.plugins.googleAnalytics', [])
         return d.promise;
       },
 
-      trackEvent: function (category, action, label, value) {
+      trackEvent: function (category, action, label, value, newSession) {
         var d = $q.defer();
 
-        $window.ga.trackEvent(category, action, label, value, function (response) {
+        $window.ga.trackEvent(category, action, label, value, newSession, function (response) {
           d.resolve(response);
         }, function (error) {
           d.reject(error);

--- a/test/plugins/googleAnalytics.spec.js
+++ b/test/plugins/googleAnalytics.spec.js
@@ -33,7 +33,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'startTrackerWithId')
-      .and.callFake(function (id, successCb, errorCb) {
+      .and.callFake(function (id, dispatchPeriod, successCb, errorCb) {
         successCb('tracker started');
       });
 
@@ -54,7 +54,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'startTrackerWithId')
-      .and.callFake(function (id, successCb, errorCb) {
+      .and.callFake(function (id, dispatchPeriod, successCb, errorCb) {
         errorCb('tracker id is not valid');
       });
 
@@ -196,7 +196,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'trackView')
-      .and.callFake(function (screenName, successCb, errorCb) {
+      .and.callFake(function (screenName, campaingUrl, newSession, successCb, errorCb) {
         successCb('Track Screen: ' + screenName);
       });
 
@@ -217,7 +217,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'trackView')
-      .and.callFake(function (screenName, successCb, errorCb) {
+      .and.callFake(function (screenName, campaingUrl, newSession, successCb, errorCb) {
         errorCb('Expected one non-empty string argument');
       });
 
@@ -277,12 +277,12 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'trackEvent')
-      .and.callFake(function (category, action, label, value, successCb, errorCb) {
+      .and.callFake(function (category, action, label, value, newSession, successCb, errorCb) {
         successCb('Track Event: ' + category);
       });
 
     $cordovaGoogleAnalytics
-      .trackEvent('Videos', 'Video Load Time', 'Gone With the Wind', 100)
+      .trackEvent('Videos', 'Video Load Time', 'Gone With the Wind', 100, false)
       .then(function (response) {
         result = response;
       });
@@ -291,7 +291,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
 
     expect(result).toBe('Track Event: Videos');
     expect($window.ga.trackEvent).toHaveBeenCalledWith(
-      'Videos', 'Video Load Time', 'Gone With the Wind', 100,
+      'Videos', 'Video Load Time', 'Gone With the Wind', 100, false,
       jasmine.any(Function),
       jasmine.any(Function)
     );
@@ -302,7 +302,7 @@ describe('Service: $cordovaGoogleAnalytics', function() {
     var result;
 
     spyOn($window.ga, 'trackEvent')
-      .and.callFake(function (category, action, label, value, successCb, errorCb) {
+      .and.callFake(function (category, action, label, value, newSession, successCb, errorCb) {
         errorCb('Tracker not started');
       });
 


### PR DESCRIPTION
The Google Analytics package that this project calls has been updated in a backwards incompatible manner.  These edits are updates to address these changes.

This API clash is currently causing users of ng-cordova to be unable to log properly in Google Analytics after fresh builds.

Note:
1. For an unknown reason (at least to me), a unit test is broken for $cordovaToast before I made any edits. Not sure what's causing it, but it should be pop up if retest your master branch as well.
2. This contains the same edits as https://github.com/driftyco/ng-cordova/pull/1392 which is based off the master branch instead, given the current release doesn't work with the current release of https://github.com/danwilson/google-analytics-plugin