### PR TITLE
fix(splashscreen): test if splashscreen exists before calling hide/sh…

### DIFF
--- a/src/plugins/splashscreen.js
+++ b/src/plugins/splashscreen.js
@@ -6,12 +6,12 @@ angular.module('ngCordova.plugins.splashscreen', [])
   .factory('$cordovaSplashscreen', [function () {
 
     return {
-      hide: function () {
-        return navigator.splashscreen.hide();
+      hide: function() {
+        return navigator.splashscreen ? navigator.splashscreen.hide() : null;
       },
 
-      show: function () {
-        return navigator.splashscreen.show();
+      show: function() {
+        return navigator.splashscreen ? navigator.splashscreen.show() : null;
       }
     };
 


### PR DESCRIPTION
When testing locally on browser (without device with ionic serve for example), splashscreen's methods hide/show keep logging errors on console since navigator.splashscreen is not defined .. Fixing it with adding a test on splashscreen existence 