### PR TITLE
Fix unhandled rejection test error

### DIFF
--- a/src/module-mocks.js
+++ b/src/module-mocks.js
@@ -1,1 +1,4 @@
 var ngCordovaMocks = angular.module('ngCordovaMocks', []);
+ngCordovaMocks.config(['$qProvider', function ($qProvider) {
+  $qProvider.errorOnUnhandledRejections(false);
+}]);

--- a/src/plugins/splashscreen.js
+++ b/src/plugins/splashscreen.js
@@ -6,12 +6,12 @@ angular.module('ngCordova.plugins.splashscreen', [])
   .factory('$cordovaSplashscreen', [function () {
 
     return {
-      hide: function () {
-        return navigator.splashscreen.hide();
+      hide: function() {
+        return navigator.splashscreen ? navigator.splashscreen.hide() : null;
       },
 
-      show: function () {
-        return navigator.splashscreen.show();
+      show: function() {
+        return navigator.splashscreen ? navigator.splashscreen.show() : null;
       }
     };
 


### PR DESCRIPTION
Bug detected with Angular 1.6.0 version. Karma tests fail with this error " ngCordovaMocks cordovaToast should show a toast FAILED". In Angular 1.5.9 to 1.6.0 there seems to be some bug with unhandled rejects..
Adding rejection config to fix it 