### PR TITLE
added result to success callback in socialSharing plugin

### DIFF
--- a/src/mocks/socialSharing.js
+++ b/src/mocks/socialSharing.js
@@ -240,7 +240,9 @@ ngCordovaMocks.factory('$cordovaSocialSharing', ['$q', function ($q) {
         this.attachments = file;
         this.link = link;
 
-        defer.resolve();
+        defer.resolve({
+          completed:true
+        });
       }
       return defer.promise;
     },

--- a/src/plugins/socialSharing.js
+++ b/src/plugins/socialSharing.js
@@ -14,8 +14,8 @@ angular.module('ngCordova.plugins.socialSharing', [])
         subject = subject || null;
         file = file || null;
         link = link || null;
-        $window.plugins.socialsharing.share(message, subject, file, link, function () {
-          q.resolve(true);
+        $window.plugins.socialsharing.share(message, subject, file, link, function (result) {
+          q.resolve(result);
         }, function () {
           q.reject(false);
         });

--- a/test/mocks/socialSharing.spec.js
+++ b/test/mocks/socialSharing.spec.js
@@ -15,7 +15,7 @@ describe('ngCordovaMocks', function() {
 		it('should share with twitter', function (done) {
 			$cordovaSocialSharing.shareViaTwitter('Check out Ecofic!', null, 'http://www.ecofic.com')
 				.then(
-					function() { expect(true).toBe(true); },
+					function() { expect(true).toBeTruthy(); },
 					function() { expect(false).toBe(true); }
 				)
 				.finally(function() { done(); })
@@ -35,7 +35,7 @@ describe('ngCordovaMocks', function() {
 			;
 
 			$rootScope.$digest();
-		});		
+		});
 
 		it('should share with whatsApp', function (done) {
 			$cordovaSocialSharing.shareViaWhatsApp('Check out Ecofic!', null, 'http://www.ecofic.com')
@@ -135,6 +135,6 @@ describe('ngCordovaMocks', function() {
 			;
 
 			$rootScope.$digest();
-		});		
+		});
 	});
 })


### PR DESCRIPTION
In the documentation of the [Social Sharing Plugin](https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin) you can see that the result in the success callback contains useful informations. In the current version it simply resolve true.