### PR TITLE
delete args check on "createBeaconRegion"

### DIFF
--- a/src/plugins/beacon.js
+++ b/src/plugins/beacon.js
@@ -129,9 +129,6 @@ angular.module('ngCordova.plugins.beacon', [])
         callbackDidChangeAuthorizationStatus = callback;
       },
       createBeaconRegion: function (identifier, uuid, major, minor, notifyEntryStateOnDisplay) {
-        major = major || undefined;
-        minor = minor || undefined;
-
         return new $window.cordova.plugins.locationManager.BeaconRegion(
           identifier,
           uuid,


### PR DESCRIPTION
major and minor are unsigned 16 bit integer.
So it can be 0.
But, when major or minor is 0,  "createBeaconRegion" overwrites it by undefined.