### PR TITLE
fix getDuration

### DIFF
--- a/src/plugins/media.js
+++ b/src/plugins/media.js
@@ -124,9 +124,7 @@ angular.module('ngCordova.plugins.media', [])
 
   NewMedia.prototype.getDuration = function () {
     q3 = $q.defer();
-    this.media.getDuration(function (duration){
-    q3.resolve(duration);
-    });
+    q3.resolve(this.media.getDuration());
     return q3.promise;
   };
 


### PR DESCRIPTION
media.getDuration() returns a value directly, so the callback on lines 127-129 is never called and q3.promise never resolves.